### PR TITLE
Simplify use of sed in okapi-login

### DIFF
--- a/okapi-scripts/okapi-login
+++ b/okapi-scripts/okapi-login
@@ -35,6 +35,6 @@ shift `expr $OPTIND - 1`
 
 AUTH_TOKEN=$(curl -sSL -D - -X POST -H 'accept: application/json' -H 'Content-type: application/json' \
     -H "X-Okapi-Tenant: $TENANT" --connect-timeout 5 --max-time 30 -d "{ \"username\":\"${UN}\", \"password\": \"${PW}\" }" \
-    "${OKAPI}/authn/login" | grep -Fi x-okapi-token | sed -r 's/^.*\:\s*(([A-Za-z0-9+\/]+\.){2}[A-Za-z0-9+\/]+)/\1/' | xargs)
+    "${OKAPI}/authn/login" | grep -Fi x-okapi-token | sed 's/.*: *//' | xargs)
 echo $AUTH_TOKEN
 exit 0


### PR DESCRIPTION
Avoids requiring GNU sed's `-r` option, which is absent on some platforms.