### PR TITLE
Tweaks to cancellation and conditionals

### DIFF
--- a/service/grails-app/controllers/mod/rs/PatronRequestController.groovy
+++ b/service/grails-app/controllers/mod/rs/PatronRequestController.groovy
@@ -199,10 +199,10 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
                                         'Cancellation denied', null);
                 patron_request.state = reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousState);
               } else {
-                patron_request.state=reshareApplicationEventHandlerService.lookupStatus('Responder', 'RES_COMPLETE')
+                patron_request.state=reshareApplicationEventHandlerService.lookupStatus('Responder', 'RES_UNFILLED')
                 reshareApplicationEventHandlerService.auditEntry(patron_request, 
                                         patron_request.state, 
-                                        reshareApplicationEventHandlerService.lookupStatus('Responder', 'RES_COMPLETE'), 
+                                        reshareApplicationEventHandlerService.lookupStatus('Responder', 'RES_UNFILLED'), 
                                         'Cancellation accepted', null);
                 patron_request.requesterRequestedCancellation = false;
               }

--- a/service/grails-app/services/org/olf/rs/HousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/rs/HousekeepingService.groovy
@@ -170,10 +170,10 @@ public class HousekeepingService {
         AvailableAction.ensure( 'PatronRequest', 'REQ_CONDITIONAL_ANSWER_RECEIVED', 'requesterRejectConditions', 'M')
         AvailableAction.ensure( 'PatronRequest', 'REQ_CONDITIONAL_ANSWER_RECEIVED', 'requesterCancel', 'M')
 
-        AvailableAction.ensure( 'PatronRequest', 'RES_CANCEL_REQUEST_RECEIVED', 'message', 'M')
-
         AvailableAction.ensure( 'PatronRequest', 'REQ_IDLE', 'cancel', 'M', 'C', CANCEL_ACTION_CLOSURE)
         AvailableAction.ensure( 'PatronRequest', 'REQ_IDLE', 'requesterCancel', 'M')
+
+        AvailableAction.ensure( 'Responder', 'REQ_CANCEL_PENDING', 'message', 'M')
 
         AvailableAction.ensure( 'PatronRequest', 'REQ_VALIDATED', 'cancel', 'M', 'C', CANCEL_ACTION_CLOSURE)
         AvailableAction.ensure( 'PatronRequest', 'REQ_VALIDATED', 'requesterCancel', 'M')

--- a/service/grails-app/services/org/olf/rs/HousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/rs/HousekeepingService.groovy
@@ -136,8 +136,8 @@ public class HousekeepingService {
         AvailableAction.ensure( 'Responder', 'RES_PENDING_CONDITIONAL_ANSWER', 'supplierMarkConditionsAgreed', 'M')
         AvailableAction.ensure( 'Responder', 'RES_PENDING_CONDITIONAL_ANSWER', 'supplierCannotSupply', 'M')
         AvailableAction.ensure( 'Responder', 'RES_PENDING_CONDITIONAL_ANSWER', 'message', 'M')
-        
-        
+
+        AvailableAction.ensure( 'Responder', 'RES_CANCEL_REQUEST_RECEIVED', 'message', 'M')
         AvailableAction.ensure( 'Responder', 'RES_CANCEL_REQUEST_RECEIVED', 'supplierRespondToCancel', 'M')
 
         AvailableAction.ensure( 'Responder', 'RES_NEW_AWAIT_PULL_SLIP', 'supplierPrintPullSlip', 'M')
@@ -169,6 +169,8 @@ public class HousekeepingService {
         AvailableAction.ensure( 'PatronRequest', 'REQ_CONDITIONAL_ANSWER_RECEIVED', 'requesterAgreeConditions', 'M')
         AvailableAction.ensure( 'PatronRequest', 'REQ_CONDITIONAL_ANSWER_RECEIVED', 'requesterRejectConditions', 'M')
         AvailableAction.ensure( 'PatronRequest', 'REQ_CONDITIONAL_ANSWER_RECEIVED', 'requesterCancel', 'M')
+
+        AvailableAction.ensure( 'PatronRequest', 'RES_CANCEL_REQUEST_RECEIVED', 'message', 'M')
 
         AvailableAction.ensure( 'PatronRequest', 'REQ_IDLE', 'cancel', 'M', 'C', CANCEL_ACTION_CLOSURE)
         AvailableAction.ensure( 'PatronRequest', 'REQ_IDLE', 'requesterCancel', 'M')

--- a/service/grails-app/services/org/olf/rs/HousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/rs/HousekeepingService.groovy
@@ -173,7 +173,7 @@ public class HousekeepingService {
         AvailableAction.ensure( 'PatronRequest', 'REQ_IDLE', 'cancel', 'M', 'C', CANCEL_ACTION_CLOSURE)
         AvailableAction.ensure( 'PatronRequest', 'REQ_IDLE', 'requesterCancel', 'M')
 
-        AvailableAction.ensure( 'Responder', 'REQ_CANCEL_PENDING', 'message', 'M')
+        AvailableAction.ensure( 'PatronRequest', 'REQ_CANCEL_PENDING', 'message', 'M')
 
         AvailableAction.ensure( 'PatronRequest', 'REQ_VALIDATED', 'cancel', 'M', 'C', CANCEL_ACTION_CLOSURE)
         AvailableAction.ensure( 'PatronRequest', 'REQ_VALIDATED', 'requesterCancel', 'M')


### PR DESCRIPTION
- Changed end state for cancelled requests on the supplier's side to `RES_UNFILLED`
- Added ability to send chat messages to new states: `RES_CANCEL_REQUEST_RECEIVED` and `REQ_CANCEL_PENDING` 