### PR TITLE
Pr 624

### DIFF
--- a/service/grails-app/controllers/mod/rs/PatronRequestController.groovy
+++ b/service/grails-app/controllers/mod/rs/PatronRequestController.groovy
@@ -40,14 +40,6 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
       if ( params.patronRequestId ) {
         def patron_request = PatronRequest.get(params.patronRequestId)
         if ( patron_request ) {
-          if( request.JSON.actionParams.pickupLocationCode ) {
-            DirectoryEntry entry = ReshareApplicationEventHandlerService
-              .resolveCombinedSymbol(request.JSON.actionParams.pickupLocationCode).owner;
-            if(entry != null) {
-              patron_request.resolvedPickupLocation = entry;
-              patron_request.pickupLocation = entry.name;
-            }
-          }
           log.debug("Apply action ${request.JSON.action} to ${patron_request}");
           switch ( request.JSON.action ) {
             case 'supplierPrintPullSlip':

--- a/service/grails-app/domain/org/olf/rs/PatronRequest.groovy
+++ b/service/grails-app/domain/org/olf/rs/PatronRequest.groovy
@@ -13,6 +13,7 @@ import org.olf.rs.statemodel.AvailableAction;
 import com.k_int.web.toolkit.tags.Tag
 import org.olf.okapi.modules.directory.Symbol;
 import java.time.LocalDate;
+import org.olf.okapi.modules.directory.DirectoryEntry;
 
 /**
  * PatronRequest - Instances of this class represent an occurrence of a patron (Researcher, Undergrad, Faculty)
@@ -90,6 +91,8 @@ class PatronRequest implements CustomProperties, MultiTenant<PatronRequest> {
   String patronEmail
   String patronNote
   String pickupLocation
+  String pickupLocationCode
+  DirectoryEntry resolvedPickupLocation
 
   // A json blob containing the response to a lookup in the shared index.
   String bibRecord
@@ -256,6 +259,8 @@ class PatronRequest implements CustomProperties, MultiTenant<PatronRequest> {
     patronEmail (nullable: true, blank:false)
     patronNote (nullable: true, blank:false)
     pickupLocation (nullable: true, blank:false)
+    pickupLocationCode (nullable: true)
+    resolvedPickupLocation (nullable: true)
 
     resolvedPatron (nullable: true)
     requesterRequestedCancellation (nullable: false, blank: false)
@@ -338,6 +343,8 @@ class PatronRequest implements CustomProperties, MultiTenant<PatronRequest> {
     patronEmail column : 'pr_patron_email'
     patronNote column : 'pr_patron_note'
     pickupLocation column : 'pr_pref_service_point'
+    pickupLocationCode column : 'pr_pref_service_point_code'
+    resolvedPickupLocation column : 'pr_resolved_pickup_location'
 
     resolvedPatron column : 'pr_resolved_patron_fk'
 

--- a/service/grails-app/domain/org/olf/rs/PatronRequest.groovy
+++ b/service/grails-app/domain/org/olf/rs/PatronRequest.groovy
@@ -344,7 +344,7 @@ class PatronRequest implements CustomProperties, MultiTenant<PatronRequest> {
     patronNote column : 'pr_patron_note'
     pickupLocation column : 'pr_pref_service_point'
     pickupLocationCode column : 'pr_pref_service_point_code'
-    resolvedPickupLocation column : 'pr_resolved_pickup_location'
+    resolvedPickupLocation column : 'pr_resolved_pickup_location_fk'
 
     resolvedPatron column : 'pr_resolved_patron_fk'
 

--- a/service/grails-app/migrations/initial-model.groovy
+++ b/service/grails-app/migrations/initial-model.groovy
@@ -1531,4 +1531,17 @@ databaseChangeLog = {
         }
     }
 
+    changeSet(author: "knordstrom (manual)", id: "20200501-1024-001") {
+      addColumn(tableName: "patron_request") {
+        column(name: "pr_pref_service_point_code", type: "VARCHAR(255)")
+      }
+    }
+
+    changeSet(author: "knordstrom (manual)", id: "20200501-1024-002") {
+      addColumn(tableName: "patron_request") {
+        column(name: "pr_resolved_pickup_location_fk", type: "VARCHAR(36)")
+      }
+      addForeignKeyConstraint(baseColumnNames: "pr_resolved_pickup_location_fk", baseTableName: "patron_request", constraintName: "FK_pickup_location_constraint", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "de_id", referencedTableName: "directory_entry")
+    }
+
 }

--- a/service/grails-app/migrations/initial-model.groovy
+++ b/service/grails-app/migrations/initial-model.groovy
@@ -1535,10 +1535,7 @@ databaseChangeLog = {
       addColumn(tableName: "patron_request") {
         column(name: "pr_pref_service_point_code", type: "VARCHAR(255)")
       }
-    }
-
-    changeSet(author: "knordstrom (manual)", id: "20200501-1024-002") {
-      addColumn(tableName: "patron_request") {
+       addColumn(tableName: "patron_request") {
         column(name: "pr_resolved_pickup_location_fk", type: "VARCHAR(36)")
       }
       addForeignKeyConstraint(baseColumnNames: "pr_resolved_pickup_location_fk", baseTableName: "patron_request", constraintName: "FK_pickup_location_constraint", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "de_id", referencedTableName: "directory_entry")

--- a/service/grails-app/services/org/olf/rs/ReshareActionService.groovy
+++ b/service/grails-app/services/org/olf/rs/ReshareActionService.groovy
@@ -11,6 +11,7 @@ import org.olf.rs.statemodel.StateModel
 import org.olf.okapi.modules.directory.Symbol;
 import groovy.json.JsonOutput;
 import java.time.LocalDateTime;
+import org.olf.okapi.modules.directory.DirectoryEntry
 import java.time.Instant;
 import org.olf.rs.lms.HostLMSActions;
 import com.k_int.web.toolkit.settings.AppSetting;
@@ -94,7 +95,14 @@ public class ReshareActionService {
   public Map notiftyPullSlipPrinted(PatronRequest pr) {
     log.debug("notiftyPullSlipPrinted(${pr})");
     Map result = [status:false];
-    pr
+    if( pr.pickupLocationCode ) {
+      DirectoryEntry entry = ReshareApplicationEventHandlerService
+        .resolveCombinedSymbol(request.JSON.actionParams.pickupLocationCode).owner;
+      if(entry != null) {
+        pr.resolvedPickupLocation = entry;
+        pr.pickupLocation = entry.name;
+      }
+    }
     Status s = Status.lookup('Responder', 'RES_AWAIT_PICKING');
     if ( s && pr.state.code=='RES_NEW_AWAIT_PULL_SLIP') {
       pr.state = s;

--- a/service/grails-app/services/org/olf/rs/ReshareActionService.groovy
+++ b/service/grails-app/services/org/olf/rs/ReshareActionService.groovy
@@ -100,7 +100,7 @@ public class ReshareActionService {
     Map result = [status:false];
     if( pr.pickupLocationCode ) {
       DirectoryEntry entry = ReshareApplicationEventHandlerService
-        .resolveCombinedSymbol(request.JSON.actionParams.pickupLocationCode).owner;
+        .resolveCombinedSymbol(request.JSON.actionParams.pickupLocationCode)?.owner;
       if(entry != null) {
         pr.resolvedPickupLocation = entry;
         pr.pickupLocation = entry.name;

--- a/service/grails-app/services/org/olf/rs/ReshareActionService.groovy
+++ b/service/grails-app/services/org/olf/rs/ReshareActionService.groovy
@@ -94,6 +94,7 @@ public class ReshareActionService {
   public Map notiftyPullSlipPrinted(PatronRequest pr) {
     log.debug("notiftyPullSlipPrinted(${pr})");
     Map result = [status:false];
+    pr
     Status s = Status.lookup('Responder', 'RES_AWAIT_PICKING');
     if ( s && pr.state.code=='RES_NEW_AWAIT_PULL_SLIP') {
       pr.state = s;


### PR DESCRIPTION
This attempts to do the following:
- Extend the data model with two fields: pickupLocationCode (string) and resolvedPickupLocation (DirectoryEntry)
- Add logic to the ReshareActionService to lookup and populate the resolvedPickupLocation based on the pickupLocationCode symbol, then populate the pickupLocation field from the resolvedPickupLocation's name.