### PR TITLE
Changes to the way we store previousStates

### DIFF
--- a/service/grails-app/controllers/mod/rs/PatronRequestController.groovy
+++ b/service/grails-app/controllers/mod/rs/PatronRequestController.groovy
@@ -101,6 +101,7 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
               result.status = reshareActionService.simpleTransition(patron_request, request.JSON.actionParams, 'PatronRequest', 'REQ_EXPECTS_TO_SUPPLY');
               break;
             case 'requesterRejectConditions':
+              patron_request.previousStates['REQ_CANCEL_PENDING'] = patron_request.state.code;
               reshareActionService.sendCancel(patron_request, request.JSON.action, request.JSON.actionParams)
               reshareApplicationEventHandlerService.auditEntry(patron_request, 
                                     reshareApplicationEventHandlerService.lookupStatus('PatronRequest', 'REQ_CONDITIONAL_ANSWER_RECEIVED'), 
@@ -109,6 +110,7 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
               result.status = reshareActionService.simpleTransition(patron_request, request.JSON.actionParams, 'PatronRequest', 'REQ_CANCEL_PENDING');
               break;
             case 'requesterCancel':
+              patron_request.previousStates['REQ_CANCEL_PENDING'] = patron_request.state.code;
               reshareActionService.sendCancel(patron_request, request.JSON.action, request.JSON.actionParams)
               result.status = reshareActionService.simpleTransition(patron_request, request.JSON.actionParams, 'PatronRequest', 'REQ_CANCEL_PENDING');
               break;
@@ -134,7 +136,8 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
                     // The supplying agency wants to go into a holding state
 
                     // In this case we want to "pretend" the previous state was actually the next one, for later when it looks up the previous state
-                    patron_request.previousState = 'RES_NEW_AWAIT_PULL_SLIP'
+                    //patron_request.previousState = 'RES_NEW_AWAIT_PULL_SLIP'
+                    patron_request.previousStates.put('RES_PENDING_CONDITIONAL_ANSWER', 'RES_NEW_AWAIT_PULL_SLIP')
                     reshareApplicationEventHandlerService.auditEntry(patron_request, 
                                         reshareApplicationEventHandlerService.lookupStatus('Responder', 'RES_IDLE'), 
                                         reshareApplicationEventHandlerService.lookupStatus('Responder', 'RES_PENDING_CONDITIONAL_ANSWER'), 
@@ -167,7 +170,8 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
                                         'Added loan condition to request, request continuing', null);
                   } else {
                     // The supplying agency wants to go into a holding state
-                    patron_request.previousState = patron_request.state.code;
+                    //patron_request.previousState = patron_request.state.code;
+                    patron_request.previousStates.put('RES_PENDING_CONDITIONAL_ANSWER', patron_request.state.code);
                     reshareApplicationEventHandlerService.auditEntry(patron_request, 
                                         patron_request.state, 
                                         reshareApplicationEventHandlerService.lookupStatus('Responder', 'RES_PENDING_CONDITIONAL_ANSWER'), 
@@ -186,12 +190,15 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
               patron_request.save(flush:true, failOnError:true);
               break;
             case 'supplierMarkConditionsAgreed':
+            /*   def s = reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousState); */
+              def s = reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousStates['RES_PENDING_CONDITIONAL_ANSWER']);
               reshareApplicationEventHandlerService.auditEntry(patron_request, 
                                     reshareApplicationEventHandlerService.lookupStatus('Responder', 'RES_PENDING_CONDITIONAL_ANSWER'),
-                                    reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousState),
+                                    s,
                                     'Conditions manually marked as agreed', null);
-              patron_request.state=reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousState)
-              patron_request.previousState = null;
+              patron_request.state=s;
+              //patron_request.previousState = null;
+              patron_request.previousStates['RES_PENDING_CONDITIONAL_ANSWER'] = null;
               patron_request.save(flush:true, failOnError:true);
               break;
             case 'supplierRespondToCancel':
@@ -199,11 +206,12 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
               // If the cancellation is denied, switch the cancel flag back to false, otherwise send request to complete
               if (request.JSON?.actionParams?.cancelResponse == "no") {
                 patron_request.requesterRequestedCancellation = false;
+                //def s = reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousState);
+                def s = reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousStates[patron_request.state.code]);
                 reshareApplicationEventHandlerService.auditEntry(patron_request, 
-                                        patron_request.state,
-                                        reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousState),
-                                        'Cancellation denied', null);
-                patron_request.state = reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousState);
+                                        patron_request.state, s, 'Cancellation denied', null);
+                patron_request.previousStates[patron_request.state.code] = null
+                patron_request.state = s;
               } else {
                 patron_request.state=reshareApplicationEventHandlerService.lookupStatus('Responder', 'RES_UNFILLED')
                 reshareApplicationEventHandlerService.auditEntry(patron_request, 

--- a/service/grails-app/controllers/mod/rs/PatronRequestController.groovy
+++ b/service/grails-app/controllers/mod/rs/PatronRequestController.groovy
@@ -136,7 +136,6 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
                     // The supplying agency wants to go into a holding state
 
                     // In this case we want to "pretend" the previous state was actually the next one, for later when it looks up the previous state
-                    //patron_request.previousState = 'RES_NEW_AWAIT_PULL_SLIP'
                     patron_request.previousStates.put('RES_PENDING_CONDITIONAL_ANSWER', 'RES_NEW_AWAIT_PULL_SLIP')
                     reshareApplicationEventHandlerService.auditEntry(patron_request, 
                                         reshareApplicationEventHandlerService.lookupStatus('Responder', 'RES_IDLE'), 
@@ -170,7 +169,6 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
                                         'Added loan condition to request, request continuing', null);
                   } else {
                     // The supplying agency wants to go into a holding state
-                    //patron_request.previousState = patron_request.state.code;
                     patron_request.previousStates.put('RES_PENDING_CONDITIONAL_ANSWER', patron_request.state.code);
                     reshareApplicationEventHandlerService.auditEntry(patron_request, 
                                         patron_request.state, 
@@ -190,14 +188,12 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
               patron_request.save(flush:true, failOnError:true);
               break;
             case 'supplierMarkConditionsAgreed':
-            /*   def s = reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousState); */
               def s = reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousStates['RES_PENDING_CONDITIONAL_ANSWER']);
               reshareApplicationEventHandlerService.auditEntry(patron_request, 
                                     reshareApplicationEventHandlerService.lookupStatus('Responder', 'RES_PENDING_CONDITIONAL_ANSWER'),
                                     s,
                                     'Conditions manually marked as agreed', null);
               patron_request.state=s;
-              //patron_request.previousState = null;
               patron_request.previousStates['RES_PENDING_CONDITIONAL_ANSWER'] = null;
               patron_request.save(flush:true, failOnError:true);
               break;
@@ -206,7 +202,6 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
               // If the cancellation is denied, switch the cancel flag back to false, otherwise send request to complete
               if (request.JSON?.actionParams?.cancelResponse == "no") {
                 patron_request.requesterRequestedCancellation = false;
-                //def s = reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousState);
                 def s = reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousStates[patron_request.state.code]);
                 reshareApplicationEventHandlerService.auditEntry(patron_request, 
                                         patron_request.state, s, 'Cancellation denied', null);

--- a/service/grails-app/domain/org/olf/rs/PatronRequest.groovy
+++ b/service/grails-app/domain/org/olf/rs/PatronRequest.groovy
@@ -166,8 +166,8 @@ class PatronRequest implements CustomProperties, MultiTenant<PatronRequest> {
   //Boolean to flag whether a request continues after the current cancellation with supplier
   boolean requestToContinue = true;
 
-  // We also sometimes need to know the state that existed before heading into a pending state
-  String previousState
+  // We also sometimes need to know the state(s) that existed before heading into a pending state--in the correct order
+  Map previousStates = [:]
 
   Patron resolvedPatron
 
@@ -276,7 +276,6 @@ class PatronRequest implements CustomProperties, MultiTenant<PatronRequest> {
     requesterRequestedCancellation (nullable: false)
     requestToContinue (nullable: false)
 
-    previousState (nullable: true)
     activeLoan(nullable: true)
     dueDateFromLMS(nullable: true)
 
@@ -364,7 +363,7 @@ class PatronRequest implements CustomProperties, MultiTenant<PatronRequest> {
     resolvedPatron column : 'pr_resolved_patron_fk'
     requesterRequestedCancellation column: 'pr_requester_requested_cancellation'
     requestToContinue column: 'pr_request_to_continue'
-    previousState column: 'pr_previous_state'
+    previousStates column: 'pr_previous_states'
     activeLoan column: 'pr_active_loan'
     needsAttention column: 'pr_needs_attention'
 

--- a/service/grails-app/migrations/initial-model.groovy
+++ b/service/grails-app/migrations/initial-model.groovy
@@ -1653,4 +1653,18 @@ databaseChangeLog = {
       }
     }
   }
+
+  changeSet(author: "efreestone (manual)", id: "202008111728-001") {
+    createTable(tableName: "patron_request_previous_states") {
+      column(name: "pr_previous_states", type: "VARCHAR(255)")
+
+      column(name: "previous_states_object", type: "VARCHAR(255)")
+
+      column(name: "previous_states_idx", type: "VARCHAR(255)")
+
+      column(name: "previous_states_elt", type: "VARCHAR(255)") {
+        constraints(nullable: "false")
+      }
+    }
+  }
 }

--- a/service/grails-app/migrations/initial-model.groovy
+++ b/service/grails-app/migrations/initial-model.groovy
@@ -1667,4 +1667,8 @@ databaseChangeLog = {
       }
     }
   }
+
+  changeSet(author: "efreestone (manual)", id: "202008111728-002") {
+    dropColumn(tableName: "patron_request", columnName: "pr_previous_state")
+  }
 }

--- a/service/grails-app/services/org/olf/rs/ReshareActionService.groovy
+++ b/service/grails-app/services/org/olf/rs/ReshareActionService.groovy
@@ -529,7 +529,6 @@ public class ReshareActionService {
   }
 
   public boolean sendCancel(PatronRequest pr, String action, Object actionParams) {
-    //pr.previousState = pr.state.code
     switch (action) {
       case 'requesterRejectedConditions':
         pr.requestToContinue = true;

--- a/service/grails-app/services/org/olf/rs/ReshareActionService.groovy
+++ b/service/grails-app/services/org/olf/rs/ReshareActionService.groovy
@@ -529,7 +529,7 @@ public class ReshareActionService {
   }
 
   public boolean sendCancel(PatronRequest pr, String action, Object actionParams) {
-    pr.previousState = pr.state.code
+    //pr.previousState = pr.state.code
     switch (action) {
       case 'requesterRejectedConditions':
         pr.requestToContinue = true;

--- a/service/grails-app/services/org/olf/rs/ReshareApplicationEventHandlerService.groovy
+++ b/service/grails-app/services/org/olf/rs/ReshareApplicationEventHandlerService.groovy
@@ -709,12 +709,10 @@ public class ReshareApplicationEventHandlerService {
                 break;
               case 'N':
                 log.debug("Negative cancel response received")
-                //def previousState = lookupStatus('PatronRequest', pr.previousState)
                 def previousState = lookupStatus('PatronRequest', pr.previousStates[pr.state.code])
                 auditEntry(pr, pr.state, previousState, "Supplier denied cancellation.", null)
                 pr.previousStates[pr.state.code] = null
                 pr.state = previousState
-                //pr.previousState = null
                 break;
               default:
                 log.error("handleSupplyingAgencyMessage does not know how to deal with a CancelResponse answerYesNo of ${eventData.messageInfo.answerYesNo}")
@@ -826,10 +824,8 @@ public class ReshareApplicationEventHandlerService {
             if (messageData.note.startsWith("#ReShareLoanConditionAgreeResponse#")) {
               // First check we're in the state where we need to change states, otherwise we just ignore this and treat as a regular message, albeit with warning
               if (pr.state.code == "RES_PENDING_CONDITIONAL_ANSWER") {
-                //def new_state = lookupStatus('Responder', pr.previousState)
                 def new_state = lookupStatus('Responder', pr.previousStates[pr.state.code])
                 auditEntry(pr, pr.state, new_state, "Requester agreed to loan conditions, moving request forward", null)
-                //pr.previousState = null;
                 pr.previousStates[pr.state.code] = null;
                 pr.state = new_state;
               } else {
@@ -844,7 +840,6 @@ public class ReshareApplicationEventHandlerService {
           case 'Cancel':
             // We cannot cancel a shipped item
             auditEntry(pr, pr.state, lookupStatus('Responder', 'RES_CANCEL_REQUEST_RECEIVED'), "Requester requested cancellation of the request", null)
-            //pr.previousState = pr.state.code;
             pr.previousStates['RES_CANCEL_REQUEST_RECEIVED'] = pr.state.code;
             pr.state = lookupStatus('Responder', 'RES_CANCEL_REQUEST_RECEIVED')
             pr.save(flush: true, failOnError: true)
@@ -891,7 +886,6 @@ public class ReshareApplicationEventHandlerService {
         // System has auto-respond cancel on
         if ( req.state?.code=='RES_ITEM_SHIPPED' ) {
           // Revert the state to it's original before the cancel request was received - previousState
-          //def new_state = lookupStatus('PatronRequest', req.previousState);
           def new_state = lookupStatus('PatronRequest', req.previousStates['RES_CANCEL_REQUEST_RECEIVED']);
           auditEntry(req, req.state, new_state, "AutoResponder:Cancel is ON - but item is SHIPPED. Responding NO to cancel, revert to previous state ", null)
           req.state=new_state

--- a/service/grails-app/services/org/olf/rs/ReshareApplicationEventHandlerService.groovy
+++ b/service/grails-app/services/org/olf/rs/ReshareApplicationEventHandlerService.groovy
@@ -709,10 +709,12 @@ public class ReshareApplicationEventHandlerService {
                 break;
               case 'N':
                 log.debug("Negative cancel response received")
-                def previousState = lookupStatus('PatronRequest', pr.previousState)
+                //def previousState = lookupStatus('PatronRequest', pr.previousState)
+                def previousState = lookupStatus('PatronRequest', pr.previousStates[pr.state.code])
                 auditEntry(pr, pr.state, previousState, "Supplier denied cancellation.", null)
+                pr.previousStates[pr.state.code] = null
                 pr.state = previousState
-                pr.previousState = null
+                //pr.previousState = null
                 break;
               default:
                 log.error("handleSupplyingAgencyMessage does not know how to deal with a CancelResponse answerYesNo of ${eventData.messageInfo.answerYesNo}")
@@ -824,9 +826,11 @@ public class ReshareApplicationEventHandlerService {
             if (messageData.note.startsWith("#ReShareLoanConditionAgreeResponse#")) {
               // First check we're in the state where we need to change states, otherwise we just ignore this and treat as a regular message, albeit with warning
               if (pr.state.code == "RES_PENDING_CONDITIONAL_ANSWER") {
-                def new_state = lookupStatus('Responder', pr.previousState)
+                //def new_state = lookupStatus('Responder', pr.previousState)
+                def new_state = lookupStatus('Responder', pr.previousStates[pr.state.code])
                 auditEntry(pr, pr.state, new_state, "Requester agreed to loan conditions, moving request forward", null)
-                pr.previousState = null;
+                //pr.previousState = null;
+                pr.previousStates[pr.state.code] = null;
                 pr.state = new_state;
               } else {
                 auditEntry(pr, pr.state, pr.state, "Requester agreed to loan conditions, no action required on supplier side", null)
@@ -840,7 +844,8 @@ public class ReshareApplicationEventHandlerService {
           case 'Cancel':
             // We cannot cancel a shipped item
             auditEntry(pr, pr.state, lookupStatus('Responder', 'RES_CANCEL_REQUEST_RECEIVED'), "Requester requested cancellation of the request", null)
-            pr.previousState = pr.state.code;
+            //pr.previousState = pr.state.code;
+            pr.previousStates['RES_CANCEL_REQUEST_RECEIVED'] = pr.state.code;
             pr.state = lookupStatus('Responder', 'RES_CANCEL_REQUEST_RECEIVED')
             pr.save(flush: true, failOnError: true)
             break;
@@ -886,9 +891,11 @@ public class ReshareApplicationEventHandlerService {
         // System has auto-respond cancel on
         if ( req.state?.code=='RES_ITEM_SHIPPED' ) {
           // Revert the state to it's original before the cancel request was received - previousState
-          def new_state = lookupStatus('PatronRequest', req.previousState);
-          req.state=new_state
+          //def new_state = lookupStatus('PatronRequest', req.previousState);
+          def new_state = lookupStatus('PatronRequest', req.previousStates['RES_CANCEL_REQUEST_RECEIVED']);
           auditEntry(req, req.state, new_state, "AutoResponder:Cancel is ON - but item is SHIPPED. Responding NO to cancel, revert to previous state ", null)
+          req.state=new_state
+          req.previousStates['RES_CANCEL_REQUEST_RECEIVED'] = null;
           reshareActionService.sendSupplierCancelResponse(req, [cancelResponse:'no'])
         }
         else {


### PR DESCRIPTION
The new property previousStates stores a Map, with keys and values of state codes.
This way we can store the previousState pertinent to each holding state, and thus back out of multiple holding states at a time.