### PR TITLE
PR-801: Removal of two unused actions

### DIFF
--- a/service/grails-app/controllers/mod/rs/PatronRequestController.groovy
+++ b/service/grails-app/controllers/mod/rs/PatronRequestController.groovy
@@ -246,9 +246,6 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
                 result.status = reshareActionService.simpleTransition(patron_request, request.JSON.actionParams,'Responder',  'RES_COMPLETE');
               }
               break;
-            case 'cancel':
-              result.status = reshareActionService.simpleTransition(patron_request, request.JSON.actionParams, 'PatronRequest', 'REQ_CANCELLED');
-              break;
             case 'requesterReceived':
               // This will trigger an NCIP acceptItem as well
               if(!reshareActionService.sendRequesterReceived(patron_request, request.JSON.actionParams)) {

--- a/service/grails-app/services/org/olf/rs/HousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/rs/HousekeepingService.groovy
@@ -131,7 +131,6 @@ public class HousekeepingService {
         AvailableAction.ensure( 'Responder', 'RES_IDLE', 'respondYes', 'M')
         AvailableAction.ensure( 'Responder', 'RES_IDLE', 'supplierCannotSupply', 'M')
         AvailableAction.ensure( 'Responder', 'RES_IDLE', 'supplierConditionalSupply', 'M')
-        AvailableAction.ensure( 'Responder', 'RES_IDLE', 'dummyAction', 'S')
 
         AvailableAction.ensure( 'Responder', 'RES_PENDING_CONDITIONAL_ANSWER', 'supplierMarkConditionsAgreed', 'M')
         AvailableAction.ensure( 'Responder', 'RES_PENDING_CONDITIONAL_ANSWER', 'supplierCannotSupply', 'M')
@@ -166,18 +165,14 @@ public class HousekeepingService {
         AvailableAction.ensure( 'PatronRequest', 'REQ_CONDITIONAL_ANSWER_RECEIVED', 'requesterRejectConditions', 'M')
         AvailableAction.ensure( 'PatronRequest', 'REQ_CONDITIONAL_ANSWER_RECEIVED', 'requesterCancel', 'M')
 
-        AvailableAction.ensure( 'PatronRequest', 'REQ_IDLE', 'cancel', 'M', 'C', CANCEL_ACTION_CLOSURE)
         AvailableAction.ensure( 'PatronRequest', 'REQ_IDLE', 'requesterCancel', 'M')
 
         AvailableAction.ensure( 'PatronRequest', 'REQ_CANCEL_PENDING', 'message', 'M')
 
-        AvailableAction.ensure( 'PatronRequest', 'REQ_VALIDATED', 'cancel', 'M', 'C', CANCEL_ACTION_CLOSURE)
         AvailableAction.ensure( 'PatronRequest', 'REQ_VALIDATED', 'requesterCancel', 'M')
 
-        AvailableAction.ensure( 'PatronRequest', 'REQ_SOURCING_ITEM', 'cancel', 'M', 'C', CANCEL_ACTION_CLOSURE)
         AvailableAction.ensure( 'PatronRequest', 'REQ_SOURCING_ITEM', 'requesterCancel', 'M')
 
-        AvailableAction.ensure( 'PatronRequest', 'REQ_SUPPLIER_IDENTIFIED', 'cancel', 'M', 'C', CANCEL_ACTION_CLOSURE)
         AvailableAction.ensure( 'PatronRequest', 'REQ_SUPPLIER_IDENTIFIED', 'requesterCancel', 'M')
 
         AvailableAction.ensure( 'PatronRequest', 'REQ_EXPECTS_TO_SUPPLY', 'message', 'M')


### PR DESCRIPTION
This will remove the actions `dummyAction` and `cancel` from any newly set up environments.
For existing environments the SQL
```
delete from available_action where aa_action_code='dummyAction';
delete from available_action where aa_action_code='cancel';
```
will need to be run