### PR TITLE
Removed 'disable NCIP' setting

### DIFF
--- a/service/grails-app/services/org/olf/rs/BaseHostLMSService.groovy
+++ b/service/grails-app/services/org/olf/rs/BaseHostLMSService.groovy
@@ -473,6 +473,7 @@ public abstract class BaseHostLMSService implements HostLMSActions {
           log.debug("Check out - no action, config ${check_out_setting?.value}");
           // Check in is not configured, so return true
           break;
+      }
     }
     return result;
   }

--- a/service/grails-app/services/org/olf/rs/BaseHostLMSService.groovy
+++ b/service/grails-app/services/org/olf/rs/BaseHostLMSService.groovy
@@ -456,13 +456,30 @@ public abstract class BaseHostLMSService implements HostLMSActions {
                           String itemBarcode,
                           String borrowerBarcode,
                           Symbol requesterDirectorySymbol) {
-    log.debug("checkoutItem(${requestId}. ${itemBarcode},${borrowerBarcode},${requesterDirectorySymbol})");
-    return ncip2CheckoutItem(requestId, itemBarcode, borrowerBarcode)
+    
+    log.debug("checkoutItem(${requestId}. ${itemBarcode},${borrowerBarcode},${requesterDirectorySymbol})");                        
+    Map result = [
+      result: true,
+      reason: 'spoofed'
+    ];
+
+    AppSetting check_out_setting = AppSetting.findByKey('check_out_item')
+    if ( ( check_out_setting != null ) && ( check_out_setting.value != null ) )  {
+      switch ( check_in_setting.value ) {
+        case 'ncip2':
+          result = ncip2CheckoutItem(requestId, itemBarcode, borrowerBarcode)
+          break;
+        default:
+          log.debug("Check out - no action, config ${check_out_setting?.value}");
+          // Check in is not configured, so return true
+          break;
+    }
+    return result;
   }
 
   public Map ncip2CheckoutItem(String requestId, String itemBarcode, String borrowerBarcode) {
 
-    Map result = [:];
+    Map result = [reason: 'ncip2'];
 
     log.debug("ncip2CheckoutItem(${itemBarcode},${borrowerBarcode})");
     AppSetting ncip_server_address_setting = AppSetting.findByKey('ncip_server_address')

--- a/service/grails-app/services/org/olf/rs/BaseHostLMSService.groovy
+++ b/service/grails-app/services/org/olf/rs/BaseHostLMSService.groovy
@@ -257,7 +257,7 @@ public abstract class BaseHostLMSService implements HostLMSActions {
       switch ( borrower_check_setting.value ) {
         case 'ncip2':
           result = ncip2LookupPatron(patron_id)
-          result['reason'] = 'ncip2'
+          result.reason = 'ncip2'
           break;
         default:
           log.debug("Borrower check - no action, config ${borrower_check_setting?.value}");
@@ -468,6 +468,7 @@ public abstract class BaseHostLMSService implements HostLMSActions {
       switch ( check_out_setting.value ) {
         case 'ncip2':
           result = ncip2CheckoutItem(requestId, itemBarcode, borrowerBarcode)
+          result.reason = 'ncip2'
           break;
         default:
           log.debug("Check out - no action, config ${check_out_setting?.value}");

--- a/service/grails-app/services/org/olf/rs/BaseHostLMSService.groovy
+++ b/service/grails-app/services/org/olf/rs/BaseHostLMSService.groovy
@@ -468,7 +468,6 @@ public abstract class BaseHostLMSService implements HostLMSActions {
       switch ( check_out_setting.value ) {
         case 'ncip2':
           result = ncip2CheckoutItem(requestId, itemBarcode, borrowerBarcode)
-          result.reason = 'ncip2'
           break;
         default:
           log.debug("Check out - no action, config ${check_out_setting?.value}");
@@ -480,7 +479,7 @@ public abstract class BaseHostLMSService implements HostLMSActions {
   }
 
   public Map ncip2CheckoutItem(String requestId, String itemBarcode, String borrowerBarcode) {
-
+    // set reason to ncip2
     Map result = [reason: 'ncip2'];
 
     log.debug("ncip2CheckoutItem(${itemBarcode},${borrowerBarcode})");

--- a/service/grails-app/services/org/olf/rs/ManualHostLMSService.groovy
+++ b/service/grails-app/services/org/olf/rs/ManualHostLMSService.groovy
@@ -34,7 +34,7 @@ public class ManualHostLMSService implements HostLMSActions {
   
   public Map lookupPatron(String patron_id) {
     log.debug("lookupPatron(${patron_id})");
-    Map result = [ status: 'OK' ];
+    Map result = [ status: 'OK', reason: 'spoofed' ];
     return result
   }
 
@@ -42,7 +42,7 @@ public class ManualHostLMSService implements HostLMSActions {
                           String itemBarcode,
                           String borrowerBarcode,
                           Symbol requesterDirectorySymbol) {
-    log.debug("checkoutItem(${itemBarcode},${borrowerBarcode},${}requesterDirectorySymbol)");
+    log.debug("checkoutItem(${itemBarcode},${borrowerBarcode},${requesterDirectorySymbol})");
     return [
       result:false
     ]

--- a/service/grails-app/services/org/olf/rs/ManualHostLMSService.groovy
+++ b/service/grails-app/services/org/olf/rs/ManualHostLMSService.groovy
@@ -44,7 +44,8 @@ public class ManualHostLMSService implements HostLMSActions {
                           Symbol requesterDirectorySymbol) {
     log.debug("checkoutItem(${itemBarcode},${borrowerBarcode},${requesterDirectorySymbol})");
     return [
-      result:false
+      result:true,
+      reason: 'spoofed'
     ]
   }
 
@@ -58,13 +59,15 @@ public class ManualHostLMSService implements HostLMSActions {
                             String pickup_location,
                             String requested_action) {
     return [
-      result:false
+      result:true,
+      reason: 'spoofed'
     ];
   }
 
   public Map checkInItem(String item_id) {
     return [
-      result:false
+      result:true,
+      reason: 'spoofed'
     ];
   }
 

--- a/service/grails-app/services/org/olf/rs/ReshareApplicationEventHandlerService.groovy
+++ b/service/grails-app/services/org/olf/rs/ReshareApplicationEventHandlerService.groovy
@@ -152,6 +152,9 @@ public class ReshareApplicationEventHandlerService {
 
         if ( patron_details.problems == null ) {
           if ( isValidPatron(patron_details) ) {
+            // Let the user know if the success came from a real call or a spoofed one
+            String message = "Patron validated. ${patron_details.reason=='spoofed' ? '(No host LMS integration configured for borrower check call)' : 'Host LMS integration: borrower check call succeeded.'}"
+            auditEntry(req, req.state, req.state, message, null);
   
             if ( patron_details.userid == null )
               patron_details.userid = req.patronIdentifier

--- a/service/src/main/okapi/tenant/sample_data/_data.groovy
+++ b/service/src/main/okapi/tenant/sample_data/_data.groovy
@@ -60,15 +60,45 @@ try {
                                   key: 'ncip_server_address'
                                   ).save(flush:true, failOnError: true);
 
+
+  // External LMS call methods -- none represents no integration and we will spoof a passing response instead
   RefdataValue.lookupOrCreate('BorrowerCheckMethod', 'None');
   RefdataValue.lookupOrCreate('BorrowerCheckMethod', 'NCIP2');
 
-  AppSetting borrower_check = AppSetting.findByKey('borrower_check') ?: new AppSetting( 
-                                  section:'requesterValidation',
+AppSetting borrower_check = AppSetting.findByKey('borrower_check') ?: new AppSetting(
+                                  section:'hostLMSIntegration',
                                   settingType:'Refdata',
                                   vocab:'BorrowerCheckMethod',
                                   key: 'borrower_check'
                                   ).save(flush:true, failOnError: true);
+
+RefdataValue.lookupOrCreate('CheckOutMethod', 'None');
+RefdataValue.lookupOrCreate('CheckOutMethod', 'NCIP2');
+  
+AppSetting host_lms_integration = AppSetting.findByKey('check_out_item') ?: new AppSetting(
+                                  section:'hostLMSIntegration',
+                                  settingType:'Refdata',
+                                  vocab:'CheckOutMethod',
+                                  key: 'check_out_item').save(flush:true, failOnError: true);
+
+RefdataValue.lookupOrCreate('CheckInMethod', 'None');
+RefdataValue.lookupOrCreate('CheckInMethod', 'NCIP2');
+  
+AppSetting host_lms_integration = AppSetting.findByKey('check_in_item') ?: new AppSetting(
+                                  section:'hostLMSIntegration',
+                                  settingType:'Refdata',
+                                  vocab:'CheckInMethod',
+                                  key: 'check_in_item').save(flush:true, failOnError: true);
+
+
+RefdataValue.lookupOrCreate('AcceptItemMethod', 'None');
+RefdataValue.lookupOrCreate('AcceptItemMethod', 'NCIP2');
+  
+AppSetting host_lms_integration = AppSetting.findByKey('accept_item') ?: new AppSetting(
+                                  section:'hostLMSIntegration',
+                                  settingType:'Refdata',
+                                  vocab:'AcceptItemMethod',
+                                  key: 'accept_item').save(flush:true, failOnError: true);
 
   AppSetting request_id_prefix = AppSetting.findByKey('request_id_prefix') ?: new AppSetting( 
                                   section:'requests',
@@ -176,17 +206,6 @@ try {
                                   vocab:'ChatAutoRead',
                                   key: 'chat_auto_read',
                                   defValue: 'on').save(flush:true, failOnError: true);
-
-  RefdataValue.lookupOrCreate('NCIPDisabled', 'Disabled');
-  def ncip_en = RefdataValue.lookupOrCreate('NCIPDisabled', 'Enabled');
-
-  AppSetting ncip_disabled = AppSetting.findByKey('ncip_disabled') ?: new AppSetting(
-                                  section:'localNCIP',
-                                  settingType:'Refdata',
-                                  vocab:'NCIPDisabled',
-                                  key: 'ncip_disabled',
-                                  defValue: ncip_en?.value).save(flush:true, failOnError: true);
-
 
   RefdataValue.lookupOrCreate('loanConditions', 'LibraryUseOnly');
   RefdataValue.lookupOrCreate('loanConditions', 'NoReproduction');

--- a/service/src/main/okapi/tenant/sample_data/_data.groovy
+++ b/service/src/main/okapi/tenant/sample_data/_data.groovy
@@ -75,7 +75,7 @@ AppSetting borrower_check = AppSetting.findByKey('borrower_check') ?: new AppSet
 RefdataValue.lookupOrCreate('CheckOutMethod', 'None');
 RefdataValue.lookupOrCreate('CheckOutMethod', 'NCIP2');
   
-AppSetting host_lms_integration = AppSetting.findByKey('check_out_item') ?: new AppSetting(
+AppSetting check_out_item = AppSetting.findByKey('check_out_item') ?: new AppSetting(
                                   section:'hostLMSIntegration',
                                   settingType:'Refdata',
                                   vocab:'CheckOutMethod',
@@ -84,7 +84,7 @@ AppSetting host_lms_integration = AppSetting.findByKey('check_out_item') ?: new 
 RefdataValue.lookupOrCreate('CheckInMethod', 'None');
 RefdataValue.lookupOrCreate('CheckInMethod', 'NCIP2');
   
-AppSetting host_lms_integration = AppSetting.findByKey('check_in_item') ?: new AppSetting(
+AppSetting check_in_item = AppSetting.findByKey('check_in_item') ?: new AppSetting(
                                   section:'hostLMSIntegration',
                                   settingType:'Refdata',
                                   vocab:'CheckInMethod',
@@ -94,7 +94,7 @@ AppSetting host_lms_integration = AppSetting.findByKey('check_in_item') ?: new A
 RefdataValue.lookupOrCreate('AcceptItemMethod', 'None');
 RefdataValue.lookupOrCreate('AcceptItemMethod', 'NCIP2');
   
-AppSetting host_lms_integration = AppSetting.findByKey('accept_item') ?: new AppSetting(
+AppSetting accept_item = AppSetting.findByKey('accept_item') ?: new AppSetting(
                                   section:'hostLMSIntegration',
                                   settingType:'Refdata',
                                   vocab:'AcceptItemMethod',


### PR DESCRIPTION
In order to preserve the flexibility of ReShare to work with other LMS systems, we now have separate settings to configure borrowerCheck, acceptItem, checkIn and checkOut as `ncip2` or `none`.

The workflow for avoiding an NCIP call is now to either turn hostLMSIntegration to `none` as a blanket "off" switch, or to individually deconfigure each external host LMS call.

As part of this work, the behaviour for HostLMSIntegration: none has changed. AcceptItem, CheckOut and CheckIn calls used to fail, they now pass with a note in the audit log that they're passing without making an external call.