### PR TITLE
Only process notice triggers for current tenant

### DIFF
--- a/service/grails-app/services/org/olf/rs/BackgroundTaskService.groovy
+++ b/service/grails-app/services/org/olf/rs/BackgroundTaskService.groovy
@@ -81,7 +81,7 @@ For this run these values are
 
   def performReshareTasks(String tenant) {
     log.debug("performReshareTasks(${tenant}) as at ${new Date()}");
-    patronNoticeService.processQueue()
+    patronNoticeService.processQueue(tenant)
 
 
     // If somehow we get asked to perform the background tasks, but a thread is already running, then just return

--- a/service/grails-app/services/org/olf/rs/PatronNoticeService.groovy
+++ b/service/grails-app/services/org/olf/rs/PatronNoticeService.groovy
@@ -89,6 +89,7 @@ public class PatronNoticeService {
   public void processQueue(String tenant) {
     log.debug("Processing patron notice queue for tenant ${tenant}");
     consumer.subscribe(["${tenant}_PatronNoticeEvents".toString()]);
+    // TODO pass a Duration object (long is deprecated) and determine a less-arbitrary amount of time
     def consumerRecords = consumer.poll(1000)
     consumerRecords.each{ record ->
       try {
@@ -125,6 +126,8 @@ public class PatronNoticeService {
       }
     }
     consumer.commitAsync();
+    // relies on commitAsync reading subscriptions up front, perhaps best to
+    // run unsubscribe afterwards by implementing OffsetCommitCallback (TODO)
     consumer.unsubscribe();
   }
 }


### PR DESCRIPTION
...because our token is only valid for that. Also add a duration to poll() as this is necessary now that we unsubscribe.