### PR TITLE
Add query passthrough endpoint for FOLIO SI PR-924

### DIFF
--- a/service/grails-app/controllers/mod/rs/SharedIndexQueryController.groovy
+++ b/service/grails-app/controllers/mod/rs/SharedIndexQueryController.groovy
@@ -1,0 +1,39 @@
+package mod.rs;
+
+import groovy.util.logging.Slf4j;
+import grails.gorm.multitenancy.CurrentTenant;
+import com.k_int.web.toolkit.settings.AppSetting;
+import org.olf.rs.FolioSharedIndexService;
+import groovyx.net.http.FromServer;
+
+@Slf4j
+@CurrentTenant
+class SharedIndexQueryController {
+
+  FolioSharedIndexService folioSharedIndexService
+
+  def query() {
+    def stream;
+    def status;
+    folioSharedIndexService.queryPassthrough(request).get() {
+      def parser = { Object cfg, FromServer fs ->
+        stream = fs.inputStream;
+        status = fs.getStatusCode();
+      }
+      // Doesn't seem to be a clear way to just disable the parser irrespective of
+      // content-type, will probably ultimately want to eschew HttpBuilder entirely
+      // for this interface
+      response.parser('application/json', parser);
+      response.parser('text/plain', parser);
+      response.success { FromServer fs ->
+        log.debug("Success response from shared index query passthrough: ${fs.getStatusCode()}");
+      }
+      response.failure { FromServer fs ->
+        log.debug("Failure response from shared index query passthrough: ${status}");
+      }
+    };
+
+    response.setStatus(status);
+    response << stream;
+  }
+}

--- a/service/grails-app/controllers/mod/rs/UrlMappings.groovy
+++ b/service/grails-app/controllers/mod/rs/UrlMappings.groovy
@@ -21,6 +21,7 @@ class UrlMappings {
     "/rs/shipments" (resources: 'shipment' )
     "/rs/timers" (resources: 'timer' )
     "/rs/hostLMSLocations" (resources: 'hostLMSLocation' )
+    "/rs/sharedIndexQuery" (controller: 'sharedIndexQuery', action: 'query', parseRequest: false)
     "/rs/directoryEntry" (resources: 'directoryEntry' )
 
     // Call /rs/refdata to list all refdata categories

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -208,6 +208,11 @@
           "permissionsRequired": [ "rs.hostlmslocations" ]
         },
         {
+          "methods": [ "GET" ],
+          "pathPattern": "/rs/sharedIndexQuery*",
+          "permissionsRequired": [ ]
+        },
+        {
           "methods": [ "GET", "POST", "PUT", "DELETE" ],
           "pathPattern": "/rs/timers*",
           "permissionsRequired": [ "rs.timers", "email.message.post" ]


### PR DESCRIPTION
This allows the frontend to offer a discovery plugin to populate the manual request creation form. Intention is to eventually generalise this to an interface that SI can optionally implement for those situations where the frontend cannot hit them directly ...unless we pivot to do a complete abstraction for querying as part of the overall SI abstraction, TBD.