### PR TITLE
Simplify GraphQL query

### DIFF
--- a/service/grails-app/services/org/olf/rs/FolioSharedIndexService.groovy
+++ b/service/grails-app/services/org/olf/rs/FolioSharedIndexService.groovy
@@ -246,7 +246,7 @@ public class FolioSharedIndexService implements SharedIndexActions {
 
   // "query": "query($id: String!) { instance_storage_instances_SINGLE(instanceId: $id) { id title holdingsRecord2 { holdingsInstance { id callNumber holdingsStatements } } } }",
     String query='''{
-  "query": "query($id: String!) { instance_storage_instances_SINGLE(instanceId: $id) { id title identifiers { identifierTypeObject { id name } } holdingsRecords2 { id callNumber illPolicy { name }  permanentLocation { name code } holdingsStatements { note statement } bareHoldingsItems { id barcode enumeration } }  identifiers { value identifierTypeObject { name } } } }",
+  "query": "query($id: String!) { instance_storage_instances_SINGLE(instanceId: $id) { id title identifiers { value identifierTypeObject { id name } } holdingsRecords2 { id callNumber illPolicy { name }  permanentLocation { name code } holdingsStatements { note statement } bareHoldingsItems { id barcode enumeration } } } }",
   "variables":{ "id":"'''+id+'''" } }'''
 
     log.debug("Sending graphql to get holdings for (${id}) \n${query}\n");


### PR DESCRIPTION
This was previously:

	query($id: String!) {
	  instance_storage_instances_SINGLE(instanceId: $id) {
	    id
	    title
	    identifiers {
	      identifierTypeObject { id name }
	    }
	    holdingsRecords2 {
	      id
	      callNumber
	      illPolicy { name }
	      permanentLocation { name code }
	      holdingsStatements { note statement }
	      bareHoldingsItems { id barcode enumeration }
	    }
	    identifiers {
	      value
	      identifierTypeObject { name }
	    }
	  }
	}

This inefficiently visits the `identifiers` sub-record twice, so I
consolidated the two clauses into one.

*NOTE.* I have not tested or even compiled this code — I just edited by eye. Clearly someone who knows how to should do this before the change is merged.