### PR TITLE
PR-1018: Request cancellation response alert displays after response has been sent

### DIFF
--- a/service/grails-app/controllers/mod/rs/PatronRequestController.groovy
+++ b/service/grails-app/controllers/mod/rs/PatronRequestController.groovy
@@ -218,9 +218,10 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
               break;
             case 'supplierRespondToCancel':
               reshareActionService.sendSupplierCancelResponse(patron_request, request.JSON.actionParams)
+              patron_request.requesterRequestedCancellation = false;
+
               // If the cancellation is denied, switch the cancel flag back to false, otherwise send request to complete
               if (request.JSON?.actionParams?.cancelResponse == "no") {
-                patron_request.requesterRequestedCancellation = false;
                 def s = reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousStates[patron_request.state.code]);
                 reshareApplicationEventHandlerService.auditEntry(patron_request, 
                                         patron_request.state, s, 'Cancellation denied', null);
@@ -232,7 +233,6 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
                                         patron_request.state, 
                                         reshareApplicationEventHandlerService.lookupStatus('Responder', 'RES_CANCELLED'), 
                                         'Cancellation accepted', null);
-                patron_request.requesterRequestedCancellation = false;
               }
 
               patron_request.save(flush:true, failOnError:true);

--- a/service/grails-app/controllers/mod/rs/PatronRequestController.groovy
+++ b/service/grails-app/controllers/mod/rs/PatronRequestController.groovy
@@ -218,8 +218,6 @@ class PatronRequestController extends OkapiTenantAwareController<PatronRequest> 
               break;
             case 'supplierRespondToCancel':
               reshareActionService.sendSupplierCancelResponse(patron_request, request.JSON.actionParams)
-              patron_request.requesterRequestedCancellation = false;
-
               // If the cancellation is denied, switch the cancel flag back to false, otherwise send request to complete
               if (request.JSON?.actionParams?.cancelResponse == "no") {
                 def s = reshareApplicationEventHandlerService.lookupStatus('Responder', patron_request.previousStates[patron_request.state.code]);

--- a/service/grails-app/domain/org/olf/rs/PatronRequest.groovy
+++ b/service/grails-app/domain/org/olf/rs/PatronRequest.groovy
@@ -174,9 +174,6 @@ class PatronRequest implements CustomProperties, MultiTenant<PatronRequest> {
    * in which case the request gets closed. 
    */ 
 
-  // Boolean to flag whether a request is currently in the process of cancellation
-  boolean requesterRequestedCancellation = false;
-
   //Boolean to flag whether a request continues after the current cancellation with supplier
   boolean requestToContinue = true;
 
@@ -302,8 +299,7 @@ class PatronRequest implements CustomProperties, MultiTenant<PatronRequest> {
     resolvedPickupLocation (nullable: true)
 
     resolvedPatron (nullable: true)
-    // these 2 are Boolean - does not support nullable - must be true or false - comment out to remove warning
-    // requesterRequestedCancellation (nullable: false)
+    // this is Boolean - does not support nullable - must be true or false - comment out to remove warning
     // requestToContinue (nullable: false)
 
     activeLoan(nullable: true)
@@ -401,7 +397,6 @@ class PatronRequest implements CustomProperties, MultiTenant<PatronRequest> {
     pickupLocationCode column : 'pr_pref_service_point_code'
     resolvedPickupLocation column : 'pr_resolved_pickup_location_fk'
     resolvedPatron column : 'pr_resolved_patron_fk'
-    requesterRequestedCancellation column: 'pr_requester_requested_cancellation'
     requestToContinue column: 'pr_request_to_continue'
     previousStates column: 'pr_previous_states'
     activeLoan column: 'pr_active_loan'

--- a/service/grails-app/migrations/module-tenant-changelog.groovy
+++ b/service/grails-app/migrations/module-tenant-changelog.groovy
@@ -2,4 +2,5 @@ databaseChangeLog = {
   include file: 'initial-customisations.groovy'
   include file: 'initial-model.groovy'
   include file: 'update-mod-rs-2-0.groovy'
+  include file: 'update-mod-rs-2-3.groovy'
 }

--- a/service/grails-app/migrations/update-mod-rs-2-3.groovy
+++ b/service/grails-app/migrations/update-mod-rs-2-3.groovy
@@ -1,0 +1,6 @@
+databaseChangeLog = {
+  // Remove unnecessary flag, just use state code instead
+    changeSet(author: "ethanfreestone (manual)", id: "2021-08-12-1205-001") {
+      dropColumn(tableName: "patron_request", columnName: "pr_requester_requested_cancellation")
+  }
+}

--- a/service/grails-app/services/org/olf/rs/ReshareApplicationEventHandlerService.groovy
+++ b/service/grails-app/services/org/olf/rs/ReshareApplicationEventHandlerService.groovy
@@ -993,7 +993,6 @@ public class ReshareApplicationEventHandlerService {
             auditEntry(pr, pr.state, lookupStatus('Responder', 'RES_CANCEL_REQUEST_RECEIVED'), "Requester requested cancellation of the request", null)
             pr.previousStates['RES_CANCEL_REQUEST_RECEIVED'] = pr.state.code;
             pr.state = lookupStatus('Responder', 'RES_CANCEL_REQUEST_RECEIVED')
-            pr.requesterRequestedCancellation = true
             pr.save(flush: true, failOnError: true)
             break;
 


### PR DESCRIPTION
Removed flag requesterRequestedCancellation from PR, instead the frontend can key off of the state code