### PR TITLE
 Use DateTimeFormatter for ReshareActionService.parseDateString PR-1099

### DIFF
--- a/service/grails-app/services/org/olf/rs/ReshareActionService.groovy
+++ b/service/grails-app/services/org/olf/rs/ReshareActionService.groovy
@@ -12,14 +12,16 @@ import org.olf.rs.statemodel.Status
 import org.olf.rs.statemodel.StateModel
 import org.olf.okapi.modules.directory.Symbol;
 import groovy.json.JsonOutput;
-import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZonedDateTime
+import java.time.ZoneOffset
 import org.olf.okapi.modules.directory.DirectoryEntry
-import java.time.Instant;
 import org.olf.rs.lms.HostLMSActions;
 import com.k_int.web.toolkit.settings.AppSetting;
 import com.k_int.web.toolkit.custprops.CustomProperty;
 import org.olf.rs.patronstore.PatronStoreActions;
-import java.text.SimpleDateFormat
 
 
 /**
@@ -1032,24 +1034,16 @@ public class ReshareActionService {
   }
   
   protected Date parseDateString(String dateString) {
-    def formatList = [
-      "yyyy-MM-dd'T'HH:mm:ssZ",
-      "yyyy-MM-dd HH:mm:ss"
-    ];
-    Date date = null;
-    formatList.any {
-      SimpleDateFormat format = new SimpleDateFormat(it);
-      try {
-        date = format.parse(dateString); 
-      } catch(Exception e) {
-        log.debug("Unable to parse date ${dateString} with format '${it}' ${e.getMessage()}");
-      }
-      if(date != null) {
-        return true;
-      }      
+    if (dateString == null) {
+      throw new Exception("Attempted to parse null as date")
     }
-    if(date == null) {
-      throw new Exception("Unable to parse " + dateString + " to date");
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd[ ]['T']HH:mm[:ss][.SSS][z][XXX][Z]")
+    Date date
+    try {
+      date = Date.from(ZonedDateTime.parse(dateString, formatter).toInstant())
+    } catch(Exception e) {
+      log.debug("Failed to parse ${dateString} as ZonedDateTime, falling back to LocalDateTime")
+      date = Date.from(LocalDateTime.parse(dateString, formatter).toInstant(ZoneOffset.UTC))
     }
     return date
   }

--- a/service/src/test/groovy/org/olf/rs/ReshareActionServiceSpec.groovy
+++ b/service/src/test/groovy/org/olf/rs/ReshareActionServiceSpec.groovy
@@ -5,10 +5,6 @@ import spock.lang.Specification
 import groovy.util.logging.Slf4j
 import java.util.Date;
 
-/**
- * A mock email service that allows the integration tests to complete without sending any actual emails
- *
- */
 @Slf4j
 class ReshareActionServiceSpec extends Specification implements ServiceUnitTest<ReshareActionService> {
 
@@ -24,9 +20,15 @@ class ReshareActionServiceSpec extends Specification implements ServiceUnitTest<
       
     where:
       datestr|expected_time
+      '2021-09-30T00:00:00Z' | 1632960000000
+      '2021-09-30 00:00' | 1632960000000
+      '2021-09-30T00:00:00-0500' | 1632978000000
+      '2021-09-30T00:00:00.000+01:00' | 1632956400000
+      // Strangely, these do not use the expected offsets
+      // '2021-09-30T00:00:00EST' | 1632978000000
+      // '2021-09-30T00:00:00BST' | 1632956400000
       '2021-09-30T00:00:00GMT' | 1632960000000
       '2021-09-30T00:00:00UTC' | 1632960000000
-      '2021-09-30T00:00:00EST' | 1632978000000
-      '2021-09-30T00:00:00BST' | 1632956400000
+      '2021-09-30T00:00:00EDT' | 1632974400000
   }
 }


### PR DESCRIPTION
It'd have been nice to use DateFormatter.parseBest() but the version of
Groovy we're using for Grails 4 doesn't support the :: method reference
so I can't pass eg. `ZonedDateTime::from` as a TemporalQuery. Tried
things like `{ ZonedDateTime.from } as TemporalQuery` also with &. but
no dice so I just worked around it.

One caveat for completeness: while it can parse more date formats than the previous code, the format string here can use some tweaking: it does have a weird issue where it's not correctly interpreting 2021-09-30T00:00:00EST (it parses it to the same timestamp as EDT which it does understand correctly) and 2021-09-30T00:00:00BST is matching something entirely else than UTC+1 as it's ~10 hours off of that. Hence the commented tests. 

https://openlibraryenvironment.atlassian.net/browse/PR-1099
