### PR TITLE
feat: RequestVolume temporaryItemBarcode

### DIFF
--- a/service/grails-app/migrations/module-tenant-changelog.groovy
+++ b/service/grails-app/migrations/module-tenant-changelog.groovy
@@ -7,4 +7,5 @@ databaseChangeLog = {
   include file: 'update-mod-rs-2-6.groovy'
   include file: 'update-mod-rs-2-7.groovy'
   include file: 'update-mod-rs-2-8.groovy'
+  include file: 'update-mod-rs-2-9.groovy'
 }

--- a/service/grails-app/migrations/update-mod-rs-2-9.groovy
+++ b/service/grails-app/migrations/update-mod-rs-2-9.groovy
@@ -1,0 +1,7 @@
+databaseChangeLog = {
+  changeSet(author: "efreestone (manual)", id: "20220407-1111-001") {
+    addColumn(tableName: "request_volume") {
+      column(name: "rv_temporary_item_barcode", type: "VARCHAR(52)")
+    }
+  }
+}

--- a/service/grails-app/services/org/olf/rs/HostLMSService.groovy
+++ b/service/grails-app/services/org/olf/rs/HostLMSService.groovy
@@ -65,26 +65,16 @@ public class HostLMSService {
     if (host_lms) {
       resultMap.hostLMS = true;
       for( def vol : volumesNotCheckedIn ) {
-        String temporaryItemBarcode; //We want to match what we created for AcceptItem
-        if(request.isRequester) {
-          if (request.volumes?.size() > 1) {
-            temporaryItemBarcode = "${request.hrid}-${vol.itemId}";
-          } else {
-            temporaryItemBarcode = request.hrid;
-          }
-        } else { //Use the actual barcode for supply-side requests
-          temporaryItemBarcode = vol.itemId;
-        }
         def checkInMap = [:];
-        def check_in_result = host_lms.checkInItem(temporaryItemBarcode);
+        def check_in_result = host_lms.checkInItem(vol.temporaryItemBarcode);
         checkInMap.result = check_in_result;
         checkInMap.volume = vol;
         String message;
         if(check_in_result?.result == true) {          
           if(check_in_result?.already_checked_in == true) {	
-            message = "NCIP CheckinItem call succeeded for item: ${temporaryItemBarcode}. ${check_in_result.reason=='spoofed' ? '(No host LMS integration configured for check in item call)' : 'Host LMS integration: CheckinItem not performed because the item was already checked in.'}"
+            message = "NCIP CheckinItem call succeeded for item: ${vol.temporaryItemBarcode}. ${check_in_result.reason=='spoofed' ? '(No host LMS integration configured for check in item call)' : 'Host LMS integration: CheckinItem not performed because the item was already checked in.'}"
           } else {
-            message = "NCIP CheckinItem call succeeded for item: ${temporaryItemBarcode}. ${check_in_result.reason=='spoofed' ? '(No host LMS integration configured for check in item call)' : 'Host LMS integration: CheckinItem call succeeded.'}"
+            message = "NCIP CheckinItem call succeeded for item: ${vol.temporaryItemBarcode}. ${check_in_result.reason=='spoofed' ? '(No host LMS integration configured for check in item call)' : 'Host LMS integration: CheckinItem call succeeded.'}"
           }          
           checkInMap.success = true;
           reshareApplicationEventHandlerService.auditEntry(request, request.state, request.state, message, null);
@@ -94,12 +84,12 @@ public class HostLMSService {
         } else {
           request.needsAttention=true;
           checkInMap.success = false;
-          message = "Host LMS integration: NCIP CheckinItem call failed for item: ${temporaryItemBarcode}. Review configuration and try again or deconfigure host LMS integration in settings. "+check_in_result.problems?.toString();
+          message = "Host LMS integration: NCIP CheckinItem call failed for item: ${vol.temporaryItemBarcode}. Review configuration and try again or deconfigure host LMS integration in settings. "+check_in_result.problems?.toString();
           reshareApplicationEventHandlerService.auditEntry(
             request,
             request.state,
             request.state,
-            "Host LMS integration: NCIP CheckinItem call failed for item: ${temporaryItemBarcode}. Review configuration and try again or deconfigure host LMS integration in settings. "+check_in_result.problems?.toString(),
+            "Host LMS integration: NCIP CheckinItem call failed for item: ${vol.temporaryItemBarcode}. Review configuration and try again or deconfigure host LMS integration in settings. "+check_in_result.problems?.toString(),
             null);
         }
         checkInMap.message = message;

--- a/service/grails-app/services/org/olf/rs/statemodel/actions/iso18626/ActionISO18626RequesterService.groovy
+++ b/service/grails-app/services/org/olf/rs/statemodel/actions/iso18626/ActionISO18626RequesterService.groovy
@@ -65,7 +65,18 @@ public abstract class ActionISO18626RequesterService extends AbstractAction {
                                     itemId: iidId,
                                     status: RequestVolume.lookupStatus(VOLUME_STATUS_AWAITING_TEMPORARY_ITEM_CREATION)
                                 );
+
                                 request.addToVolumes(rv);
+                                
+                                /*
+                                    This _should_ be handled on the following save,
+                                    but there seems to not be an intial save which
+                                    adds the temporary barcode necessary for acceptItem.
+                                    Since these are added sequentially, in known multivol cases
+                                    we can enforce the multivolume rule so that the first item
+                                    does not rely on `volumes.size() > 1`
+                                */
+                                rv.temporaryItemBarcode = rv.generateTemporaryItemBarcode(true)
                             }
                         }
                     }
@@ -79,7 +90,15 @@ public abstract class ActionISO18626RequesterService extends AbstractAction {
                             itemId: itemId,
                             status: RequestVolume.lookupStatus(VOLUME_STATUS_AWAITING_TEMPORARY_ITEM_CREATION)
                         );
+
                         request.addToVolumes(rv);
+
+                        /*
+                            This _should_ be handled on the following save,
+                            but there seems to not be an intial save which
+                            adds the temporary barcode necessary for acceptItem.
+                        */
+                        rv.temporaryItemBarcode = rv.generateTemporaryItemBarcode()
                     }
                 }
             }

--- a/service/grails-app/views/requestVolume/_requestVolume.gson
+++ b/service/grails-app/views/requestVolume/_requestVolume.gson
@@ -2,4 +2,4 @@ import groovy.transform.*
 import org.olf.rs.RequestVolume;
 
 @Field RequestVolume requestVolume
-json g.render(requestVolume, [includes: ['id', 'name', 'itemId', 'status'], expand: ['status']])
+json g.render(requestVolume, [includes: ['id', 'name', 'itemId', 'status', 'temporaryItemBarcode'], expand: ['status']])


### PR DESCRIPTION
Added new field to RequestVolume, temporaryItemBarcode. On validate, this will be populated using a generation function, taking into account each itemId, the request hrid, whether the attached request is from the requester/supplier side and how many volumes are attached. From here the temporaryItemBarcode is stored so it can be reliably called on again in future for each item.

Also ensured that all code usages use this new stored value, and that the ActionISO18626RequesterService deliberately creates these temporaryItemBarcodes on the requester side, since there does not seem to be a save/validate cycle before they are needed.

PR-1281