### PR TITLE
Guard against null code param in GenericCodeNameService PR-1387

### DIFF
--- a/service/grails-app/services/org/olf/rs/GenericCodeNameService.groovy
+++ b/service/grails-app/services/org/olf/rs/GenericCodeNameService.groovy
@@ -31,6 +31,9 @@ public class GenericCodeNameService<TDomainClass> {
     public TDomainClass ensureExists(String code, String name, Closure additionalFieldsUpdate = null) {
         log.debug('Entering GenericCodeNameService::ensureExists(' + code + ', ' + name + ');');
 
+        // We cannot create/look up a record with a null code
+        if (code == null) return null;
+
         // We first look it up in the current session
         TDomainClass instance = domainClass.findByCode(code);
 


### PR DESCRIPTION
While the lms adapters tend to check for it, there is at least one location where this can be called with null so best to be safe: https://github.com/openlibraryenvironment/mod-rs/blob/e090f6f35be707f4fc9f83a41a6526b6df462593/service/grails-app/services/org/olf/rs/ReshareApplicationEventHandlerService.groovy#L295