### PR TITLE
Expose file definition endpoint PR-1423

### DIFF
--- a/service/grails-app/controllers/mod/rs/UrlMappings.groovy
+++ b/service/grails-app/controllers/mod/rs/UrlMappings.groovy
@@ -31,6 +31,7 @@ class UrlMappings {
     "/rs/report/execute" (controller: "report", action: "execute")
     "/rs/report/generatePicklist" (controller: "report", action: "generatePicklist")
 
+    "/rs/fileDefinition" (resources: 'fileDefinition')
     "/rs/fileDefinition/fileUpload" (controller: "fileDefinition", action: "fileUpload")
     "/rs/fileDefinition/fileDownload/$fileId" (controller: "fileDefinition", action: "fileDownload")
 

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -259,7 +259,7 @@
         },
         {
           "methods": [ "GET" ],
-          "pathPattern": "/rs/fileDefinition/fileDownload",
+          "pathPattern": "/rs/fileDefinition*",
           "permissionsRequired": [ "rs.file.download" ]
         },
         {


### PR DESCRIPTION
There was currently no way to access the file definition record. Does this seem like a sensible approach @chaswoodfield or were you thinking of something more granular?