### PR TITLE
Support ItemFormat field on new patron request and send to responder

### DIFF
--- a/service/grails-app/domain/org/olf/rs/PatronRequest.groovy
+++ b/service/grails-app/domain/org/olf/rs/PatronRequest.groovy
@@ -30,6 +30,10 @@ class PatronRequest implements CustomProperties, MultiTenant<PatronRequest> {
   @CategoryId(ProtocolReferenceDataValue.CATEGORY_PUBLICATION_TYPE)
   ProtocolReferenceDataValue publicationType
 
+  @Defaults(['Printed', 'URL'])
+  @CategoryId(ProtocolReferenceDataValue.CATEGORY_ITEM_FORMAT)
+  ProtocolReferenceDataValue itemFormat
+
 
   // A string representing the institution of the requesting patron
   // resolvable in the directory.
@@ -270,6 +274,7 @@ class PatronRequest implements CustomProperties, MultiTenant<PatronRequest> {
     awaitingProtocolResponse (bindable: false)
     rotaPosition (nullable: true, bindable: false)
     publicationType (nullable: true)
+    itemFormat (nullable: true)
 
     title (nullable: true, blank : false, maxSize:255)
     author (nullable: true, blank : false)
@@ -378,6 +383,7 @@ class PatronRequest implements CustomProperties, MultiTenant<PatronRequest> {
     awaitingProtocolResponse column : 'pr_awaiting_protocol_response'
     rotaPosition column : 'pr_rota_position'
     publicationType column : 'pr_pub_type_fk'
+    itemFormat column : 'pr_item_format_fk'
 
     title column : 'pr_title'
     author column : 'pr_author'

--- a/service/grails-app/domain/org/olf/rs/ProtocolReferenceDataValue.groovy
+++ b/service/grails-app/domain/org/olf/rs/ProtocolReferenceDataValue.groovy
@@ -8,12 +8,22 @@ import grails.gorm.MultiTenant
 class ProtocolReferenceDataValue extends RefdataValue implements MultiTenant<ProtocolReferenceDataValue>{
 
 	static public final String CATEGORY_PUBLICATION_TYPE = "request.publicationType";
+    static public final String CATEGORY_ITEM_FORMAT = "request.itemFormat";
 	static public final String CATEGORY_SERVICE_LEVEL    = "request.serviceLevel";
 	static public final String CATEGORY_SERVICE_TYPE     = "request.serviceType";
 
     static public final String SERVICE_TYPE_LOAN = "Loan";
 
 	static hasMany = [protocolConversions : ProtocolConversion];
+
+    /**
+     * Looks to see if the supplied value is a valid service type and if so returns the ProtocolReferenceDataValue for it
+     * @param value The service type to lookup
+     * @return The ProtocolReferenceDataValue that represents the service type being looked up, which may be null if it is not found
+     */
+    static public ProtocolReferenceDataValue lookupItemFormat(String value) {
+        return(lookup(CATEGORY_ITEM_FORMAT, value));
+    }
 
     /**
      * Looks to see if the supplied value is a valid publication type and if so returns the ProtocolReferenceDataValue for it

--- a/service/grails-app/migrations/module-tenant-changelog.groovy
+++ b/service/grails-app/migrations/module-tenant-changelog.groovy
@@ -10,7 +10,8 @@ databaseChangeLog = {
   include file: 'update-mod-rs-2-9.groovy'
   include file: 'update-mod-rs-2-11.groovy'
   include file: 'update-mod-rs-2-12.groovy'
-  
+  include file: 'update-mod-rs-2-13.groovy'
+
   // Pulled in from web-toolkit-ce
   include file: 'wtk/additional_CustomPropertyDefinitions.feat.groovy'
   include file: 'wtk/multi-value-custprops.feat.groovy'

--- a/service/grails-app/migrations/update-mod-rs-2-13.groovy
+++ b/service/grails-app/migrations/update-mod-rs-2-13.groovy
@@ -1,0 +1,8 @@
+databaseChangeLog = {
+    changeSet(author: "jskomorowski", id: "20230306-1245-001") {
+        addColumn(tableName: "patron_request") {
+            column(name: "pr_item_format_fk", type: "varchar(36)")
+        }
+        addForeignKeyConstraint(baseColumnNames: "pr_item_format_fk", baseTableName: "patron_request", constraintName: "FK_pr_item_format", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
+    }
+}

--- a/service/grails-app/services/org/olf/rs/ProtocolMessageBuildingService.groovy
+++ b/service/grails-app/services/org/olf/rs/ProtocolMessageBuildingService.groovy
@@ -91,6 +91,7 @@ class ProtocolMessageBuildingService {
       placeOfPublication: req.placeOfPublication
     ]
     message.serviceInfo = [
+       preferredFormat: req.itemFormat?.value,
       //TODO the following fields are permitted here but not currently included:
       /*
        * RequestType

--- a/service/grails-app/services/org/olf/rs/ProtocolMessageService.groovy
+++ b/service/grails-app/services/org/olf/rs/ProtocolMessageService.groovy
@@ -612,6 +612,7 @@ and sa.service.businessFunction.value=:ill
     void makeServiceInfo(def del, eventData) {
     exec(del) {
       serviceInfo {
+        preferredFormat(eventData.serviceInfo.preferredFormat)
         serviceType(eventData.serviceInfo.serviceType)
         needBeforeDate(eventData.serviceInfo.needBeforeDate)
         serviceLevel(eventData.serviceInfo.serviceLevel)

--- a/service/grails-app/services/org/olf/rs/statemodel/events/EventMessageRequestIndService.groovy
+++ b/service/grails-app/services/org/olf/rs/statemodel/events/EventMessageRequestIndService.groovy
@@ -88,6 +88,9 @@ public class EventMessageRequestIndService extends AbstractEvent {
             // Add service information to Patron Request
             Map serviceInfo = eventData.serviceInfo;
             if (serviceInfo != null) {
+                if (serviceInfo.preferredFormat) {
+                    pr.itemFormat = pr.lookupItemFormat(serviceInfo.preferredFormat);
+                }
                 if (serviceInfo.serviceType) {
                     pr.serviceType = pr.lookupServiceType(serviceInfo.serviceType);
                 }

--- a/service/grails-app/views/patronRequest/_patronRequest.gson
+++ b/service/grails-app/views/patronRequest/_patronRequest.gson
@@ -9,6 +9,7 @@ final def toExpand = fullRecord ? [
   'state',
   'serviceType',
   'publicationType',
+  'itemFormat',
   'pickLocation',
   'pickShelvingLocation',
   'rota',
@@ -27,6 +28,7 @@ final def toExpand = fullRecord ? [
   'pickShelvingLocation',
   'resolvedSupplier',
   'serviceType',
+  'itemFormat',
   'state'
 ]
 


### PR DESCRIPTION
While the field is called ItemFormat (in keeping with the 2021 standard) it's sent as PreferredFormat (as we currently implement 2017).

Beyond more fully reflecting the standard, this may be useful to differentiate eg. requests that are a good candidate to fill via CDL.