### PR TITLE
Match publicationType vocabulary to standard PR-1689

### DIFF
--- a/service/grails-app/domain/org/olf/rs/PatronRequest.groovy
+++ b/service/grails-app/domain/org/olf/rs/PatronRequest.groovy
@@ -26,7 +26,7 @@ class PatronRequest implements CustomProperties, MultiTenant<PatronRequest> {
   // internal ID of the patron request
   String id
 
-  @Defaults(['Book', 'Journal', 'Other'])
+  @Defaults(['ArchiveMaterial', 'Article', 'AudioBook', 'Book', 'Chapter', 'ConferenceProc', 'Game', 'GovernmentPubl', 'Image', 'Journal', 'Manuscript', 'Map', 'Movie', 'MusicRecording', 'MusicScore', 'Newspaper', 'Patent', 'Report', 'SoundRecording', 'Thesis'])
   @CategoryId(ProtocolReferenceDataValue.CATEGORY_PUBLICATION_TYPE)
   ProtocolReferenceDataValue publicationType
 

--- a/service/grails-app/migrations/update-mod-rs-2-16.groovy
+++ b/service/grails-app/migrations/update-mod-rs-2-16.groovy
@@ -17,4 +17,10 @@ databaseChangeLog = {
             where("rdv_value='copy-non-returnable'")
         }
     }
+
+    changeSet(author: "jskomorowski", id: "20240422-1300-001") {
+        delete(tableName: 'refdata_value') {
+            where("rdv_owner in (select rdc_id from refdata_category where rdc_description='request.publicationType') AND rdv_value='other'")
+        }
+    }
 }


### PR DESCRIPTION
Many values from the open code were not present. And one extraneous value, 'other' was. Removing that in a migration proved educational: liquibase data migrations seemingly can't do joins, but luckily they support subselects.