### PR TITLE
Pr 1708 (#675)

### DIFF
--- a/service/grails-app/services/org/olf/rs/statemodel/events/EventStatusResCancelRequestReceivedIndService.groovy
+++ b/service/grails-app/services/org/olf/rs/statemodel/events/EventStatusResCancelRequestReceivedIndService.groovy
@@ -20,6 +20,9 @@ public class EventStatusResCancelRequestReceivedIndService extends AbstractEvent
 
     ReshareActionService reshareActionService;
 
+    private static final String SETTING_REQUEST_ITEM_NCIP = "ncip";
+
+
     @Override
     String name() {
         return(Events.EVENT_STATUS_RES_CANCEL_REQUEST_RECEIVED_INDICATION);


### PR DESCRIPTION
* Add sending of CancelRequestItem (when relevant) on request cancel

* Make cancel request item conditional on not responding 'no' to cancel request

* Add back missing import

* Add check for CancelRequestItem to SupplierCannotSupply action

* Add missing imports/declarations

* Fix type error in CancelRequestItem call

* Cleanup

* Cleanup

* Bump version of lib-ncip-client

* Add field to PatronRequest, 'externalHoldRequestId' to store requestId for RequestItem/CancelRequestItem calls

* Move cancelRequestItem handling to EventStatusResCancelRequestRecievedInd

* Add missing constant