### PR TITLE
ILLDEV-2

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,6 +26,10 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
+      # login to gh packages for crosslink repo
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.ID_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.ID_GHCR_USER }}" --password-stdin
+
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
+      # login to gh packages for crosslink repo
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.ID_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.ID_GHCR_USER }}" --password-stdin
+
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v2
 

--- a/nodirectory.md
+++ b/nodirectory.md
@@ -1,3 +1,4 @@
+# mod-rs without mod-directory
 Changes have been implemented to allow mod-rs to function without an external directory, allowing the rota and selection of peers to be handled by an external broker.
 
 In order to put mod-rs in this mode of operation, the `routing_adapter` setting in the **Routing** section needs to be set to 'disabled'. This will inform mod-rs that we will not attempt to build a rota, nor will we pull from a rota when sending messages on to a lender.
@@ -7,3 +8,15 @@ To accomodate the lack of a rota, there are two crucial settings that need to be
 The second setting is `default_peer_symbol` in the **Requests** section. This should be populated to be the qualified symbol name that the broker will be using, so that mod-rs can populate the appropriate sections of the iso18626 message headers.
 
 It is worth noting that mod-rs will still need entries in its local directory entry that correspond with the sending and recieving symbols from the external broker, but these entries can simply be stubs and do not require services to be defined.
+
+## CI
+There are two tenants currently used to test ReShare witout directory:
+
+* https://sydney-dev.au.reshare.indexdata.com
+* https://melbourne-dev.au.reshare.indexdata.com
+
+### Deploy mod-rs
+To deploy mod-rs to this environment, run the "trove-dev-deploy" action from the master branch of mod-rs: https://github.com/openlibraryenvironment/mod-rs/actions/workflows/trove-dev-deploy.yml
+
+### Deploy UI
+To deploy a new UI for these tenants, run the "deploy" action from the dev branch of platform-trove: https://github.com/indexdata/platform-trove/actions/workflows/deploy.yml. Make sure to use dev and not the main branch.

--- a/nodirectory.md
+++ b/nodirectory.md
@@ -1,0 +1,9 @@
+Changes have been implemented to allow mod-rs to function without an external directory, allowing the rota and selection of peers to be handled by an external broker.
+
+In order to put mod-rs in this mode of operation, the `routing_adapter` setting in the **Routing** section needs to be set to 'disabled'. This will inform mod-rs that we will not attempt to build a rota, nor will we pull from a rota when sending messages on to a lender.
+
+To accomodate the lack of a rota, there are two crucial settings that need to be populated. The first is `iso18626_gateway_address` in the **Network** section. This should be the URL of the iso18626 endpoint of the broker that will be handling sending and receiving of iso message to and from mod-rs.
+
+The second setting is `default_peer_symbol` in the **Requests** section. This should be populated to be the qualified symbol name that the broker will be using, so that mod-rs can populate the appropriate sections of the iso18626 message headers.
+
+It is worth noting that mod-rs will still need entries in its local directory entry that correspond with the sending and recieving symbols from the external broker, but these entries can simply be stubs and do not require services to be defined.

--- a/service/grails-app/conf/application.groovy
+++ b/service/grails-app/conf/application.groovy
@@ -3,3 +3,4 @@ import javax.persistence.*
 grails.gorm.default.mapping = {
   '*'(accessType: AccessType.PROPERTY)
 }
+

--- a/service/grails-app/conf/application.yml
+++ b/service/grails-app/conf/application.yml
@@ -3,6 +3,7 @@
 # All root settings (anything not under the 'environements' key) here are loaded for every profile. 
 ###
 
+
 reshare:
     patronNoticesEnabled: true
 
@@ -226,6 +227,8 @@ events:
 ##
 environments:
   test:
+    server:
+      port: 22553
     dataSource:
       url: "jdbc:postgresql://${db.host:localhost}:${db.port:54321}/${db.database:okapi_modules}?ApplicationName=mod-rs-test"
       properties:

--- a/service/grails-app/services/org/olf/rs/ProtocolMessageBuildingService.groovy
+++ b/service/grails-app/services/org/olf/rs/ProtocolMessageBuildingService.groovy
@@ -95,7 +95,8 @@ class ProtocolMessageBuildingService {
       authorOfComponent: req.authorOfComponent,
       sponsor: req.sponsor,
       informationSource: req.informationSource,
-      supplierUniqueRecordId: null,   // Set later on from rota where we store the supplier id
+      //supplierUniqueRecordId: null,   // Set later on from rota where we store the supplier id
+      supplierUniqueRecordId: req.isRequester ? req.supplierUniqueRecordId : null
 
     ]
     message.publicationInfo = [

--- a/service/grails-app/services/org/olf/rs/ProtocolMessageService.groovy
+++ b/service/grails-app/services/org/olf/rs/ProtocolMessageService.groovy
@@ -173,9 +173,6 @@ class ProtocolMessageService {
 
     assert eventData != null
     assert eventData.messageType != null;
-    //assert peer_symbol != null;
-
-    //code for null peer symbol goes here
 
     List<ServiceAccount> ill_services_for_peer;
 

--- a/service/grails-app/services/org/olf/rs/ProtocolMessageService.groovy
+++ b/service/grails-app/services/org/olf/rs/ProtocolMessageService.groovy
@@ -127,9 +127,10 @@ class ProtocolMessageService {
      */
     public String buildProtocolId(PatronRequest request, String stateModel) {
         String id = (request.hrid ?: request.id)
+        String order = request.rotaPosition?.toString() ?: "norota";
         String suffix = (stateModel == StateModel.MODEL_SLNP_REQUESTER ||
                 stateModel == StateModel.MODEL_SLNP_RESPONDER) ? "" :
-                (REQUESTER_ID_SEPARATOR + request.rotaPosition.toString())
+                (REQUESTER_ID_SEPARATOR + order)
         return id + suffix
 
     }

--- a/service/grails-app/services/org/olf/rs/ReshareActionService.groovy
+++ b/service/grails-app/services/org/olf/rs/ReshareActionService.groovy
@@ -272,6 +272,9 @@ public class ReshareActionService {
                 ];
             } else if (routingDisabled) {
                 String defaultPeerSymbolString = settingsService.getSettingValue(SettingsData.SETTING_DEFAULT_PEER_SYMBOL);
+                if (!defaultPeerSymbolString) {
+                    log.error("No defaultPeerSymbol defined");
+                }
                 symbols = [
                         senderSymbol: pr.requestingInstitutionSymbol,
                         receivingSymbol: defaultPeerSymbolString

--- a/service/grails-app/services/org/olf/rs/SettingsService.groovy
+++ b/service/grails-app/services/org/olf/rs/SettingsService.groovy
@@ -15,12 +15,15 @@ public class SettingsService implements ISettings {
 		String result = null;
 
 		// Look up the setting
-		AppSetting appSetting = AppSetting.findByKey(setting);
-		if (appSetting != null) {
-			result = appSetting.value;
-			if (result == null) {
-				// Take the default value
-				result = appSetting.defValue;
+
+		if (setting) {
+			AppSetting appSetting = AppSetting.findByKey(setting);
+			if (appSetting != null) {
+				result = appSetting.value;
+				if (result == null) {
+					// Take the default value
+					result = appSetting.defValue;
+				}
 			}
 		}
 

--- a/service/grails-app/services/org/olf/rs/statemodel/StatusService.groovy
+++ b/service/grails-app/services/org/olf/rs/statemodel/StatusService.groovy
@@ -316,13 +316,13 @@ public class StatusService {
                         log.debug("No actionEventResult from availableAction, checking actionEvent")
                         if (actionEvent.resultList != null) {
                             // We have a second bite of the cherry
-                            log.debug("Looking up actionEventResult with result ${successful}, qualifier ${qualifier} and fromStatus ${fromStatus}");
+                            log.debug("Looking up actionEventResult with result ${successful}, qualifier ${qualifier} and fromStatus ${fromStatus?.code}");
                             actionEventResult = actionEvent.resultList.lookupResult(successful, qualifier, fromStatus);
                         }
 
                         // If we still didn;t find a result log an error
                         if (actionEventResult == null) {
-                            log.error('Looking up the to status, but unable to find an ActionEventResult for Status: ' + fromStatus.code +
+                            log.error('Looking up the to status, but unable to find an ActionEventResult for Status: ' + fromStatus?.code +
                                 ', action: ' + actionCode +
                                 ', successful: ' + successful +
                                 ', qualifier: ' + qualifier);

--- a/service/grails-app/services/org/olf/rs/statemodel/actions/ActionPatronRequestShippedReturnService.groovy
+++ b/service/grails-app/services/org/olf/rs/statemodel/actions/ActionPatronRequestShippedReturnService.groovy
@@ -22,7 +22,6 @@ public class ActionPatronRequestShippedReturnService extends AbstractAction {
     ActionResultDetails performAction(PatronRequest request, Object parameters, ActionResultDetails actionResultDetails) {
         // Decrement the active borrowing counter - we are returning the item
         statisticsService.decrementCounter(Counter.COUNTER_ACTIVE_BORROWING);
-
         reshareActionService.sendRequestingAgencyMessage(request, 'ShippedReturn', parameters, actionResultDetails);
 
         actionResultDetails.responseResult.status = true;

--- a/service/grails-app/services/org/olf/rs/statemodel/events/EventISO18626IncomingRequesterService.groovy
+++ b/service/grails-app/services/org/olf/rs/statemodel/events/EventISO18626IncomingRequesterService.groovy
@@ -2,7 +2,9 @@ package org.olf.rs.statemodel.events;
 
 import org.olf.rs.PatronRequest;
 import org.olf.rs.ProtocolMessageService;
-import org.olf.rs.ReshareActionService;
+import org.olf.rs.ReshareActionService
+import org.olf.rs.SettingsService
+import org.olf.rs.referenceData.SettingsData;
 import org.olf.rs.statemodel.EventResultDetails;
 import org.olf.rs.statemodel.Events;
 
@@ -15,6 +17,7 @@ public class EventISO18626IncomingRequesterService extends EventISO18626Incoming
 
     ProtocolMessageService protocolMessageService;
     ReshareActionService reshareActionService;
+    SettingsService settingsService;
 
     @Override
     public String name() {
@@ -54,9 +57,15 @@ public class EventISO18626IncomingRequesterService extends EventISO18626Incoming
         // By default we assume it is not
         boolean isCorrectRotaLocation = false;
 
+
+        String requestRouterSetting = settingsService.getSettingValue(SettingsData.SETTING_ROUTING_ADAPTER);
+
         // First of all we will see if the rota position is in the id field
         long idRotaPosition = protocolMessageService.extractRotaPositionFromProtocolId(eventData.header?.requestingAgencyRequestId);
         if (idRotaPosition < 0) {
+            if (requestRouterSetting == "disabled") {
+                return true; //There's no rota, so it'll be the correct position
+            }
             // We failed to find the rota position, so we need to fallback on checking symbols, this can still fail as the same location can be in the rota multiple times
             Map symbols = reshareActionService.requestingAgencyMessageSymbol(request);
             if (symbols.receivingSymbol != null) {

--- a/service/grails-app/services/org/olf/rs/statemodel/events/EventSendToNextLenderService.groovy
+++ b/service/grails-app/services/org/olf/rs/statemodel/events/EventSendToNextLenderService.groovy
@@ -64,15 +64,12 @@ public abstract class EventSendToNextLenderService extends AbstractEvent {
             Boolean sendSuccess = reshareActionService.sendProtocolMessage(request, request.requestingInstitutionSymbol,
                     defaultPeerSymbolString, requestMessageRequest);
             if (!sendSuccess) {
-                log.warn('Unable to send with disabled router');
-                eventResultDetails.qualifier = ActionEventResultQualifier.QUALIFIER_END_OF_ROTA;
-                eventResultDetails.auditMessage = 'End of rota';
+                log.warn("Unable to send with disabled router: ${request?.networkStatus.toString()}");
+                eventResultDetails.auditMessage = 'Problem sending to supplier gateway, will retry';
             } else {
-                log.debug("Sent to lender");
+                log.debug("Sent to supplier gateway");
             }
-
-        }
-        else if (request.rota.size() > 0) {
+        } else if (request.rota.size() > 0) {
             boolean messageTried  = false;
             boolean lookAtNextResponder = true;
 

--- a/service/grails-app/services/org/olf/rs/statemodel/events/EventSendToNextLenderService.groovy
+++ b/service/grails-app/services/org/olf/rs/statemodel/events/EventSendToNextLenderService.groovy
@@ -43,6 +43,7 @@ public abstract class EventSendToNextLenderService extends AbstractEvent {
     EventResultDetails processEvent(PatronRequest request, Map eventData, EventResultDetails eventResultDetails) {
         log.debug("Got request (HRID Is ${request.hrid}) (Status code is ${request.state?.code})");
 
+
         String requestRouterSetting = settingsService.getSettingValue(SettingsData.SETTING_ROUTING_ADAPTER);
 
         // Set the network status to Idle, just in case we do not attempt to send the message, to avoid confusion

--- a/service/grails-app/services/org/olf/rs/statemodel/events/EventSendToNextLenderService.groovy
+++ b/service/grails-app/services/org/olf/rs/statemodel/events/EventSendToNextLenderService.groovy
@@ -12,7 +12,7 @@ import org.olf.rs.ProtocolMessageService;
 import org.olf.rs.ProtocolType;
 import org.olf.rs.ReshareActionService;
 import org.olf.rs.SettingsService;
-import org.olf.rs.lms.ItemLocation
+import org.olf.rs.lms.ItemLocation;
 import org.olf.rs.referenceData.SettingsData;
 import org.olf.rs.statemodel.AbstractEvent;
 import org.olf.rs.statemodel.ActionEventResultQualifier;
@@ -32,7 +32,8 @@ public abstract class EventSendToNextLenderService extends AbstractEvent {
     ProtocolMessageBuildingService protocolMessageBuildingService;
     ProtocolMessageService protocolMessageService;
     ReshareActionService reshareActionService;
-    SettingsService settingsService;
+    //We can't rely on DI here because it apparently doesn't work when the class is called via inheritance
+    SettingsService settingsService = new SettingsService();
 
     EventFetchRequestMethod fetchRequestMethod() {
         return(EventFetchRequestMethod.PAYLOAD_ID);
@@ -43,8 +44,7 @@ public abstract class EventSendToNextLenderService extends AbstractEvent {
     EventResultDetails processEvent(PatronRequest request, Map eventData, EventResultDetails eventResultDetails) {
         log.debug("Got request (HRID Is ${request.hrid}) (Status code is ${request.state?.code})");
 
-
-        String requestRouterSetting = settingsService.getSettingValue(SettingsData.SETTING_ROUTING_ADAPTER);
+        String requestRouterSetting = settingsService.getSettingValue('routing_adapter');
 
         // Set the network status to Idle, just in case we do not attempt to send the message, to avoid confusion
         request.networkStatus = NetworkStatus.Idle;

--- a/service/grails-app/services/org/olf/rs/statemodel/events/EventStatusReqUnfilledIndService.groovy
+++ b/service/grails-app/services/org/olf/rs/statemodel/events/EventStatusReqUnfilledIndService.groovy
@@ -1,5 +1,10 @@
-package org.olf.rs.statemodel.events;
+package org.olf.rs.statemodel.events
 
+import org.olf.rs.PatronRequest
+import org.olf.rs.SettingsService
+import org.olf.rs.referenceData.SettingsData
+import org.olf.rs.statemodel.ActionEventResultQualifier
+import org.olf.rs.statemodel.EventResultDetails;
 import org.olf.rs.statemodel.Events;
 
 /**
@@ -8,6 +13,22 @@ import org.olf.rs.statemodel.Events;
  *
  */
 public class EventStatusReqUnfilledIndService extends EventSendToNextLenderService {
+
+    SettingsService settingsService;
+
+    @Override
+    EventResultDetails processEvent(PatronRequest request, Map eventData, EventResultDetails eventResultDetails) {
+
+        String requestRouterSetting = settingsService.getSettingValue(SettingsData.SETTING_ROUTING_ADAPTER);
+        if (requestRouterSetting == "disabled") {
+            log.warn("Routing disabled, end of rota reached");
+            eventResultDetails.qualifier = ActionEventResultQualifier.QUALIFIER_END_OF_ROTA;
+            eventResultDetails.auditMessage = 'End of rota';
+            return eventResultDetails;
+        }
+
+        return super.processEvent(request, eventData, eventResultDetails);
+    }
 
     @Override
     String name() {

--- a/service/grails-app/services/org/olf/rs/statemodel/events/EventStatusReqValidatedIndService.groovy
+++ b/service/grails-app/services/org/olf/rs/statemodel/events/EventStatusReqValidatedIndService.groovy
@@ -4,7 +4,9 @@ import com.k_int.web.toolkit.settings.AppSetting;
 import org.olf.rs.AvailabilityStatement;
 import org.olf.rs.PatronRequest;
 import org.olf.rs.PatronRequestRota;
-import org.olf.rs.RequestRouterService;
+import org.olf.rs.RequestRouterService
+import org.olf.rs.SettingsService
+import org.olf.rs.referenceData.SettingsData;
 import org.olf.rs.routing.RankedSupplier;
 import org.olf.rs.routing.RequestRouter;
 import org.olf.rs.statemodel.AbstractEvent;
@@ -21,6 +23,7 @@ import org.olf.rs.statemodel.Events;
 public class EventStatusReqValidatedIndService extends AbstractEvent {
 
     RequestRouterService requestRouterService;
+    SettingsService settingsService;
 
     @Override
     String name() {
@@ -39,7 +42,13 @@ public class EventStatusReqValidatedIndService extends AbstractEvent {
         eventResultDetails.qualifier = ActionEventResultQualifier.QUALIFIER_SOURCING;
         eventResultDetails.auditMessage = 'Sourcing potential items';
 
-        if (request.rota?.size() != 0) {
+        String requestRouterSetting = settingsService.getSettingValue(SettingsData.SETTING_ROUTING_ADAPTER);
+
+        if (requestRouterSetting == "disabled") {
+            eventResultDetails.qualifier = null;
+            eventResultDetails.auditMessage = 'Request router disabled';
+        }
+        else if (request.rota?.size() != 0) {
             eventResultDetails.qualifier = null;
             eventResultDetails.auditMessage = 'Request supplied with Lending String';
         } else {

--- a/service/src/integration-test/groovy/org/olf/AppSettingSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/AppSettingSpec.groovy
@@ -3,7 +3,8 @@ package org.olf
 import grails.testing.mixin.integration.Integration;
 import grails.gorm.multitenancy.Tenants;
 import groovy.json.JsonBuilder;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 import org.olf.rs.referenceData.SettingsData;
@@ -13,6 +14,7 @@ import org.olf.rs.ReferenceDataService;
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class AppSettingSpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/ApplicationSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/ApplicationSpec.groovy
@@ -1,12 +1,14 @@
 package org.olf
 
 import grails.testing.mixin.integration.Integration;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class ApplicationSpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/AvailableActionSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/AvailableActionSpec.groovy
@@ -4,12 +4,14 @@ import org.olf.rs.statemodel.Actions;
 import org.olf.rs.statemodel.StateModel;
 
 import grails.testing.mixin.integration.Integration;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class AvailableActionSpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/BatchSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/BatchSpec.groovy
@@ -2,12 +2,14 @@ package org.olf
 
 import grails.testing.mixin.integration.Integration;
 import groovy.json.JsonBuilder;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class BatchSpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/DirectoryEntrySpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/DirectoryEntrySpec.groovy
@@ -5,12 +5,14 @@ import com.k_int.web.toolkit.refdata.RefdataValue;
 import grails.gorm.multitenancy.Tenants;
 import grails.testing.mixin.integration.Integration;
 import groovy.json.JsonBuilder;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class DirectoryEntrySpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/EmailServiceSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/EmailServiceSpec.groovy
@@ -2,6 +2,7 @@ package org.olf
 
 import grails.testing.mixin.integration.Integration
 import grails.transaction.*
+import org.springframework.boot.test.context.SpringBootTest
 import spock.lang.*
 import geb.spock.*
 import groovy.util.logging.Slf4j
@@ -13,6 +14,7 @@ import org.olf.rs.EmailService
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class EmailServiceSpec extends GebSpec {
   
   def grailsApplication

--- a/service/src/integration-test/groovy/org/olf/ExternalApiSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/ExternalApiSpec.groovy
@@ -1,12 +1,14 @@
 package org.olf
 
 import grails.testing.mixin.integration.Integration;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class ExternalApiSpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/FileDefinitionSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/FileDefinitionSpec.groovy
@@ -7,12 +7,14 @@ import org.apache.http.entity.mime.MultipartEntityBuilder;
 
 import grails.testing.mixin.integration.Integration;
 import grails.web.http.HttpHeaders;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class FileDefinitionSpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/HostLMSItemLoanPolicySpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/HostLMSItemLoanPolicySpec.groovy
@@ -2,12 +2,14 @@ package org.olf
 
 import grails.testing.mixin.integration.Integration;
 import groovy.json.JsonBuilder;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class HostLMSItemLoanPolicySpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/HostLMSLocationSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/HostLMSLocationSpec.groovy
@@ -2,12 +2,14 @@ package org.olf
 
 import grails.testing.mixin.integration.Integration;
 import groovy.json.JsonBuilder;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class HostLMSLocationSpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/HostLMSPatronProfileSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/HostLMSPatronProfileSpec.groovy
@@ -2,12 +2,14 @@ package org.olf
 
 import grails.testing.mixin.integration.Integration;
 import groovy.json.JsonBuilder;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class HostLMSPatronProfileSpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/HostLMSShelvingLocationSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/HostLMSShelvingLocationSpec.groovy
@@ -2,12 +2,14 @@ package org.olf
 
 import grails.testing.mixin.integration.Integration;
 import groovy.json.JsonBuilder;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class HostLMSShelvingLocationSpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/JiscDiscoverLifecycleSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/JiscDiscoverLifecycleSpec.groovy
@@ -2,6 +2,7 @@ package org.olf
 
 import grails.testing.mixin.integration.Integration
 import grails.transaction.*
+import org.springframework.boot.test.context.SpringBootTest
 import spock.lang.*
 import geb.spock.*
 import groovy.util.logging.Slf4j
@@ -15,6 +16,7 @@ import com.k_int.web.toolkit.testing.HttpSpec
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class JiscDiscoverLifecycleSpec extends HttpSpec {
   
   // Warning: You will notice that these directory entries carry and additional customProperty: AdditionalHeaders

--- a/service/src/integration-test/groovy/org/olf/NoILLAddressSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/NoILLAddressSpec.groovy
@@ -293,7 +293,7 @@ class NoILLAddressSpec extends TestBase {
 
         when: "We create a request"
 
-        changeSettings( requesterTenantId, [ (SettingsData.SETTING_NETWORK_ISO18626_GATEWAY_ADDRESS) : "http://localhost:8081/iso18626".toString() ] );
+        changeSettings( requesterTenantId, [ (SettingsData.SETTING_NETWORK_ISO18626_GATEWAY_ADDRESS) : "http://localhost:19083/iso18626".toString() ] );
         changeSettings( requesterTenantId, [ (SettingsData.SETTING_DEFAULT_PEER_SYMBOL) : "${SYMBOL_AUTHORITY}:${SYMBOL_TWO_NAME}"]);
         //changeSettings( responderTenantId, [ (SettingsData.SETTING_NETWORK_ISO18626_GATEWAY_ADDRESS) : "${baseUrl}/rs/externalApi/iso18626".toString() ] );
 
@@ -348,7 +348,7 @@ class NoILLAddressSpec extends TestBase {
 
         when: "We create a request"
 
-        changeSettings( requesterTenantId, [ (SettingsData.SETTING_NETWORK_ISO18626_GATEWAY_ADDRESS) : "http://localhost:8081/iso18626".toString() ] );
+        changeSettings( requesterTenantId, [ (SettingsData.SETTING_NETWORK_ISO18626_GATEWAY_ADDRESS) : "http://localhost:19083/iso18626".toString() ] );
         changeSettings( requesterTenantId, [ (SettingsData.SETTING_DEFAULT_PEER_SYMBOL) : "${SYMBOL_AUTHORITY}:${SYMBOL_TWO_NAME}"]);
         //changeSettings( responderTenantId, [ (SettingsData.SETTING_NETWORK_ISO18626_GATEWAY_ADDRESS) : "${baseUrl}/rs/externalApi/iso18626".toString() ] );
 
@@ -382,10 +382,10 @@ class NoILLAddressSpec extends TestBase {
 
         when: "We post a new request to the mock to act as a requester"
         String requestBody = new File("src/integration-test/resources/isoMessages/illmockrequest.xml").text;
-        changeSettings(responderTenantId, [ (SettingsData.SETTING_NETWORK_ISO18626_GATEWAY_ADDRESS) : "http://localhost:8081/iso18626".toString() ] );
+        changeSettings(responderTenantId, [ (SettingsData.SETTING_NETWORK_ISO18626_GATEWAY_ADDRESS) : "http://localhost:19083/iso18626".toString() ] );
         changeSettings(responderTenantId, [ (SettingsData.SETTING_DEFAULT_PEER_SYMBOL) : "${SYMBOL_AUTHORITY}:${SYMBOL_TWO_NAME}"]);
 
-        sendXMLMessage("http://localhost:8081/iso18626".toString(), requestBody, null, 10000);
+        sendXMLMessage("http://localhost:19083/iso18626".toString(), requestBody, null, 10000);
 
         String requestId = waitForRequestState(responderTenantId, 10000, patronReference, Status.RESPONDER_IDLE);
 

--- a/service/src/integration-test/groovy/org/olf/NoILLAddressSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/NoILLAddressSpec.groovy
@@ -1,0 +1,276 @@
+package org.olf
+
+import grails.databinding.SimpleMapDataBindingSource
+import grails.gorm.multitenancy.Tenants
+import grails.testing.mixin.integration.Integration
+import grails.web.databinding.GrailsWebDataBinder
+import groovy.util.logging.Slf4j
+import org.olf.okapi.modules.directory.DirectoryEntry
+import org.olf.rs.referenceData.SettingsData
+import org.olf.rs.routing.RankedSupplier
+import org.olf.rs.routing.StaticRouterService
+import org.olf.rs.statemodel.Status
+import org.springframework.boot.test.context.SpringBootTest
+import spock.lang.Shared
+import spock.lang.Stepwise
+
+@Slf4j
+@Integration
+@Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT) //Otherwise the port will be random
+class NoILLAddressSpec extends TestBase {
+
+    final static String TENANT_ONE_NAME = "NIAInstOne";
+    final static String TENANT_TWO_NAME = "NIAInstTwo";
+    final static String SYMBOL_AUTHORITY = "DMMY";
+    final static String SYMBOL_ONE_NAME = "NIA1";
+    final static String SYMBOL_TWO_NAME = "NIA2";
+    final static String TENANT_ONE_DB = (TENANT_ONE_NAME + "_mod_rs").toLowerCase();
+    final static String TENANT_TWO_DB = (TENANT_TWO_NAME + "_mod_rs").toLowerCase();
+
+    @Shared
+    private static List<Map> DIRECTORY_INFO = [
+            [ id:'RS-T-D-0001',
+              name: TENANT_ONE_NAME,
+              slug:'NIA_INST_ONE',
+              symbols: [[ authority:SYMBOL_AUTHORITY, symbol:SYMBOL_ONE_NAME, priority:'a']],
+              type : "Institution"
+            ],
+            [ id:'RS-T-D-0002',
+              name: TENANT_TWO_NAME,
+              slug:'NIA_INST_TWO',
+              symbols: [[ authority:SYMBOL_AUTHORITY, symbol:SYMBOL_TWO_NAME, priority:'a']],
+              type: "Institution"
+            ]
+    ];
+
+    StaticRouterService staticRouterService;
+    GrailsWebDataBinder grailsWebDataBinder;
+
+
+
+    def setupSpecWithSpring() {
+        super.setupSpecWithSpring();
+        log.debug("setup spec completed")
+    }
+
+    public String getBaseUrl() {
+        //For some reason the base url keeps getting 'null' inserted into it
+        return super.getBaseUrl()?.replace("null", "");
+    }
+
+    private String waitForRequestState(String tenant, long timeout, String patron_reference, String required_state) {
+        Map params = [
+                'max':'100',
+                'offset':'0',
+                'match':'patronReference',
+                'term':patron_reference
+        ];
+        return waitForRequestStateParams(tenant, timeout, params, required_state);
+    }
+
+    private String waitForRequestStateById(String tenant, long timeout, String id, String required_state) {
+        Map params = [
+                'max':'1',
+                'offset':'0',
+                'match':'id',
+                'term':id
+        ];
+        return waitForRequestStateParams(tenant, timeout, params, required_state);
+    }
+
+    private String waitForRequestStateByHrid(String tenant, long timeout, String hrid, String required_state) {
+        Map params = [
+                'max':'1',
+                'offset':'0',
+                'match':'hrid',
+                'term':hrid
+        ]
+        return waitForRequestStateParams(tenant, timeout, params, required_state);
+    }
+
+    private String waitForRequestStateParams(String tenant, long timeout, Map params, String required_state) {
+        long start_time = System.currentTimeMillis();
+        String request_id = null;
+        String request_state = null;
+        long elapsed = 0;
+        while ( ( required_state != request_state ) &&
+                ( elapsed < timeout ) ) {
+
+            setHeaders(['X-Okapi-Tenant': tenant]);
+            // https://east-okapi.folio-dev.indexdata.com/rs/patronrequests?filters=isRequester%3D%3Dtrue&match=patronGivenName&perPage=100&sort=dateCreated%3Bdesc&stats=true&term=Michelle
+            def resp = doGet("${baseUrl}rs/patronrequests",
+                    params)
+            if (resp?.size() == 1) {
+                request_id = resp[0].id
+                request_state = resp[0].state?.code
+            } else {
+                log.debug("waitForRequestState: Request with params ${params} not found");
+            }
+
+            if (required_state != request_state) {
+                // Request not found OR not yet in required state
+                log.debug("Not yet found.. sleeping");
+                Thread.sleep(1000);
+            }
+            elapsed = System.currentTimeMillis() - start_time
+        }
+        log.debug("Found request on tenant ${tenant} with params ${params} in state ${request_state} after ${elapsed} milliseconds");
+
+        if ( required_state != request_state ) {
+            throw new Exception("Expected ${required_state} but timed out waiting, current state is ${request_state}");
+        }
+
+        return request_id;
+    }
+
+    void "Attempt to delete any old tenants"(tenantid, name) {
+        when:"We post a delete request"
+        boolean result = deleteTenant(tenantid, name);
+
+        then:"Any old tenant removed"
+        assert(result);
+
+        where:
+        tenantid | name
+        TENANT_ONE_NAME| TENANT_ONE_NAME
+        TENANT_TWO_NAME | TENANT_TWO_NAME
+    }
+
+    void "Set up test tenants"(tenantid, name) {
+        when:"We post a new tenant request to the OKAPI controller"
+        boolean response = setupTenant(tenantid, name);
+
+        then:"The response is correct"
+        assert(response);
+
+        where:
+        tenantid | name
+        TENANT_ONE_NAME | TENANT_ONE_NAME
+        TENANT_TWO_NAME | TENANT_TWO_NAME
+    }
+
+    void "Bootstrap directory data for integration tests"(String tenant_id, List<Map> dirents) {
+        when:"Load the default directory (test url is ${baseUrl})"
+        boolean result = true
+
+        Tenants.withId(tenant_id.toLowerCase()+'_mod_rs') {
+            log.info("Filling out dummy directory entries for tenant ${tenant_id}");
+
+            dirents.each { entry ->
+
+                log.debug("Sync directory entry ${entry} - Detected runtime port is ${serverPort}")
+                def SimpleMapDataBindingSource source = new SimpleMapDataBindingSource(entry)
+                DirectoryEntry de = new DirectoryEntry()
+                grailsWebDataBinder.bind(de, source)
+
+                try {
+                    de.save(flush:true, failOnError:true)
+                    log.debug("Result of bind: ${de} ${de.id}");
+                }
+                catch ( Exception e ) {
+                    log.error("problem bootstrapping directory data",e);
+                    result = false;
+                }
+
+                if ( de.errors ) {
+                    de.errors?.allErrors?.each { err ->
+                        log.error(err?.toString())
+                    }
+                }
+            }
+        }
+
+        then:"Test directory entries are present"
+        assert result == true
+
+        where:
+        tenant_id | dirents
+        TENANT_ONE_NAME | DIRECTORY_INFO
+        TENANT_TWO_NAME | DIRECTORY_INFO
+    }
+
+    @Shared
+    private final TENANT_ONE_SETTINGS_VISIBLE = [
+            'auto_responder_status':'off',
+            'auto_responder_cancel': 'off',
+            'routing_adapter':'static',
+            'static_routes':"${SYMBOL_AUTHORITY}:${SYMBOL_TWO_NAME}",
+            'auto_rerequest':'yes',
+            'request_id_prefix' : 'TENANTONE',
+            (SettingsData.SETTING_NETWORK_ISO18626_GATEWAY_ADDRESS) : "${baseUrl}/rs/externalApi/iso18626".toString()
+    ];
+
+    @Shared
+    private final TENANT_ONE_SETTINGS_HIDDEN = [];
+
+    @Shared
+    private final TENANT_TWO_SETTINGS_VISIBLE = [
+            'auto_responder_status':'off',
+            'auto_responder_cancel': 'off',
+            'routing_adapter':'static',
+            'static_routes':"${SYMBOL_AUTHORITY}:${SYMBOL_ONE_NAME}",
+            'request_id_prefix' : 'TENANTTWO',
+            (SettingsData.SETTING_NETWORK_ISO18626_GATEWAY_ADDRESS) : "${baseUrl}/rs/externalApi/iso18626".toString()
+    ];
+
+    @Shared
+    private final TENANT_TWO_SETTINGS_HIDDEN = [];
+
+    void "Configure Tenants for lending without rota or directory"(String tenant_id, Map changes_needed, Map changes_needed_hidden) {
+        when:"We fetch the existing settings for ${tenant_id}"
+
+        changeSettings(tenant_id, changes_needed);
+        changeSettings(tenant_id, changes_needed_hidden, true)
+
+        then:"Tenant is configured"
+        1==1
+
+
+        where:
+        tenant_id          | changes_needed               | changes_needed_hidden
+        TENANT_ONE_NAME    | [ 'auto_responder_status':'off', 'auto_responder_cancel': 'off', 'routing_adapter':'disabled',  'auto_rerequest':'yes',  'request_id_prefix' : 'TENANTONE' ] | ['requester_returnables_state_model':'PatronRequest', 'responder_returnables_state_model':'Responder', 'requester_non_returnables_state_model':'NonreturnableRequester', 'responder_non_returnables_state_model':'NonreturnableResponder', 'requester_digital_returnables_state_model':'DigitalReturnableRequester', 'state_model_responder_cdl':'CDLResponder']
+        TENANT_TWO_NAME    | [ 'auto_responder_status':'off', 'auto_responder_cancel': 'off', 'routing_adapter':'disabled',  'request_id_prefix' : 'TENANTTWO' ] | ['requester_returnables_state_model':'PatronRequest', 'responder_returnables_state_model':'Responder', 'requester_non_returnables_state_model':'NonreturnableRequester', 'responder_non_returnables_state_model':'NonreturnableResponder', 'requester_digital_returnables_state_model':'DigitalReturnableRequester', 'state_model_responder_cdl':'CDLResponder']
+    }
+
+
+    void "Test a interaction with mock"() {
+        String requesterTenantId = TENANT_ONE_NAME;
+        String responderTenantId = TENANT_TWO_NAME;
+        String patronIdentifier = "22-33-44";
+        String patronReference = "ref-${patronIdentifier}";
+        String systemInstanceIdentifier = "007-008-009";
+
+        when: "We create a request"
+
+        changeSettings( requesterTenantId, [ (SettingsData.SETTING_NETWORK_ISO18626_GATEWAY_ADDRESS) : "http://localhost:8081/iso18626".toString() ] );
+        changeSettings( requesterTenantId, [ (SettingsData.SETTING_DEFAULT_PEER_SYMBOL) : "${SYMBOL_AUTHORITY}:${SYMBOL_TWO_NAME}"]);
+        //changeSettings( responderTenantId, [ (SettingsData.SETTING_NETWORK_ISO18626_GATEWAY_ADDRESS) : "${baseUrl}/rs/externalApi/iso18626".toString() ] );
+
+        Map request = [
+                patronReference: patronReference,
+                title: "A test of the no ILL address system",
+                author: "Lilly, Noel",
+                requestingInstitutionSymbol: "${SYMBOL_AUTHORITY}:${SYMBOL_ONE_NAME}",
+                patronIdentifier: patronIdentifier,
+                isRequester: true,
+                systemInstanceIdentifier: systemInstanceIdentifier,
+                supplierUniqueRecordId: "WILLSUPPLY_LOANED"
+        ];
+
+        setHeaders([ 'X-Okapi-Tenant': requesterTenantId ]);
+        doPost("${baseUrl}/rs/patronrequests".toString(), request);
+
+        waitForRequestState(requesterTenantId, 10000, patronReference, Status.PATRON_REQUEST_REQUEST_SENT_TO_SUPPLIER);
+
+        waitForRequestState(requesterTenantId, 10000, patronReference, Status.PATRON_REQUEST_UNFILLED);
+        //String responderRequestId = waitForRequestState(responderTenantId, 10000, patronReference, Status.RESPONDER_IDLE);
+        //log.debug("Responder (terminal transition test) request id is ${responderRequestId}");
+
+
+
+        then:
+        assert(true);
+    }
+
+}

--- a/service/src/integration-test/groovy/org/olf/NoILLAddressSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/NoILLAddressSpec.groovy
@@ -50,7 +50,6 @@ class NoILLAddressSpec extends TestBase {
             ]
     ];
 
-    StaticRouterService staticRouterService;
     GrailsWebDataBinder grailsWebDataBinder;
 
 
@@ -58,6 +57,21 @@ class NoILLAddressSpec extends TestBase {
     def setupSpecWithSpring() {
         super.setupSpecWithSpring();
         log.debug("setup spec completed")
+    }
+
+    //Do we need to make sure the base version doesn't happen?
+    def setupSpec() {
+        log.debug("setupSpec called");
+    }
+
+    def setup() {
+        if (testctx.niaInitialized == null) {
+            testctx.niaInitialized = true;
+        }
+    }
+
+    def cleanup() {
+        log.debug("Cleanup called");
     }
 
     public String getBaseUrl() {
@@ -183,7 +197,7 @@ class NoILLAddressSpec extends TestBase {
 
         where:
         tenantid | name
-        TENANT_ONE_NAME| TENANT_ONE_NAME
+        TENANT_ONE_NAME | TENANT_ONE_NAME
         TENANT_TWO_NAME | TENANT_TWO_NAME
     }
 

--- a/service/src/integration-test/groovy/org/olf/NoticeSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/NoticeSpec.groovy
@@ -9,12 +9,14 @@ import org.olf.rs.NoticeEvent;
 import org.olf.rs.Patron
 import org.olf.rs.PatronNoticeService
 import org.olf.rs.PatronRequest
-import org.olf.rs.referenceData.RefdataValueData;
+import org.olf.rs.referenceData.RefdataValueData
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class NoticeSpec extends TestBase {
 
     PatronNoticeService patronNoticeService;

--- a/service/src/integration-test/groovy/org/olf/RSLifecycleSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/RSLifecycleSpec.groovy
@@ -25,6 +25,7 @@ import org.olf.rs.routing.StaticRouterService
 import org.olf.rs.settings.ISettings
 import org.olf.rs.statemodel.Status
 import org.olf.rs.timers.TimerCheckForStaleSupplierRequestsService
+import org.springframework.boot.test.context.SpringBootTest
 import spock.lang.Shared
 import spock.lang.Stepwise
 import spock.lang.Ignore
@@ -34,6 +35,7 @@ import java.text.SimpleDateFormat
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class RSLifecycleSpec extends TestBase {
 
     // The scenario details that are maintained between tests

--- a/service/src/integration-test/groovy/org/olf/SLNPStateModelSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/SLNPStateModelSpec.groovy
@@ -12,12 +12,14 @@ import org.olf.rs.PatronRequest
 import org.olf.rs.routing.RankedSupplier
 import org.olf.rs.routing.StaticRouterService
 import org.olf.rs.statemodel.*
+import org.springframework.boot.test.context.SpringBootTest
 import spock.lang.Shared
 import spock.lang.Stepwise
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class SLNPStateModelSpec extends TestBase {
 
     @Shared

--- a/service/src/integration-test/groovy/org/olf/ShelvingLocationSiteSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/ShelvingLocationSiteSpec.groovy
@@ -2,12 +2,14 @@ package org.olf
 
 import grails.testing.mixin.integration.Integration;
 import groovy.json.JsonBuilder;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class ShelvingLocationSiteSpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/ShipmentSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/ShipmentSpec.groovy
@@ -5,12 +5,14 @@ import com.k_int.web.toolkit.refdata.RefdataValue
 import grails.gorm.multitenancy.Tenants
 import grails.testing.mixin.integration.Integration;
 import groovy.json.JsonBuilder;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class ShipmentSpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/StatusSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/StatusSpec.groovy
@@ -3,12 +3,14 @@ package org.olf
 import org.olf.rs.statemodel.Status;
 
 import grails.testing.mixin.integration.Integration;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class StatusSpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/TemplateContainerSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/TemplateContainerSpec.groovy
@@ -5,12 +5,14 @@ import com.k_int.web.toolkit.refdata.RefdataValue;
 import grails.gorm.multitenancy.Tenants;
 import grails.testing.mixin.integration.Integration;
 import groovy.json.JsonBuilder;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class TemplateContainerSpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/groovy/org/olf/TestBase.groovy
+++ b/service/src/integration-test/groovy/org/olf/TestBase.groovy
@@ -28,7 +28,7 @@ class TestBase extends HttpSpec {
     @Autowired
     EventBus targetEventBus
 
-    @Value('${local.server.port}')
+    @Value(value = '${local.server.port}')
     Integer serverPort;
 
     /** Contains the tenants that have the ref data loaded */

--- a/service/src/integration-test/groovy/org/olf/TimerSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/TimerSpec.groovy
@@ -2,12 +2,14 @@ package org.olf
 
 import grails.testing.mixin.integration.Integration;
 import groovy.json.JsonBuilder;
-import groovy.util.logging.Slf4j;
+import groovy.util.logging.Slf4j
+import org.springframework.boot.test.context.SpringBootTest;
 import spock.lang.Stepwise;
 
 @Slf4j
 @Integration
 @Stepwise
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class TimerSpec extends TestBase {
 
     // This method is declared in the HttpSpec

--- a/service/src/integration-test/resources/isoMessages/illmockrequest.xml
+++ b/service/src/integration-test/resources/isoMessages/illmockrequest.xml
@@ -1,0 +1,76 @@
+<ISO18626Message xmlns="http://illtransactions.org/2013/iso18626"
+                 xmlns:ill="http://illtransactions.org/2013/iso18626"
+                 ill:version="1.2"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://illtransactions.org/2013/iso18626 http://illtransactions.org/schemas/ISO-18626-v1_2.xsd">
+    <request>
+        <header>
+            <supplyingAgencyId>
+                <agencyIdType>DMMY</agencyIdType>
+                <agencyIdValue>NIA1</agencyIdValue>
+            </supplyingAgencyId>
+            <requestingAgencyId>
+                <agencyIdType>DMMY</agencyIdType>
+                <agencyIdValue>NIA2</agencyIdValue>
+            </requestingAgencyId>
+            <multipleItemRequestId></multipleItemRequestId>
+            <timestamp>0001-01-01T00:00:00.000Z</timestamp>
+            <requestingAgencyRequestId>DMMYNIA2-1</requestingAgencyRequestId>
+        </header>
+        <bibliographicInfo>
+            <!--
+              specify supplier scenario via <supplierUniqueRecordId> field, see https://github.com/indexdata/crosslink/blob/main/illmock/README.md#supplier-behavior
+            -->
+            <!--
+              NOTE: when submitting a PatronRequest where the broker is the supplier peer (default),
+              and assuming the broker is configured with the mock SRU holdings adapter (also default),
+              you can specify multiple ILL scenarios for each mock supplier located by the broker with a semicolon separated list, e.g.:
+               <supplierUniqueRecordId>ERROR;UNFILLED;WILLSUPPLY_UNFILLED;LOANED</supplierUniqueRecordId>
+            -->
+            <supplierUniqueRecordId>LOANED</supplierUniqueRecordId>
+            <title>Layered of the Rungs</title>
+            <author>Junior Tooken</author>
+            <bibliographicItemId>
+                <bibliographicItemIdentifier>1884</bibliographicItemIdentifier>
+                <bibliographicItemIdentifierCode>ISBN</bibliographicItemIdentifierCode>
+            </bibliographicItemId>
+            <bibliographicRecordId>
+                <bibliographicRecordIdentifierCode ill:scheme="RESHARE">patronReference</bibliographicRecordIdentifierCode>
+                <bibliographicRecordIdentifier>ref-33-44-55</bibliographicRecordIdentifier>
+            </bibliographicRecordId>
+        </bibliographicInfo>
+        <serviceInfo>
+            <requestType>New</requestType>
+            <!--
+              use requestSubType:PatronRequest ONLY if the mock should act as a requester and send a request to the supplier peer (broker by default)
+            -->
+            <requestSubType>PatronRequest</requestSubType>
+            <serviceType>Loan</serviceType>
+            <!--
+              specify requester behavior via the <note> field, see https://github.com/indexdata/crosslink/blob/main/illmock/README.md#requester-behavior
+            -->
+              <note>#CANCEL#</note>
+        </serviceInfo>
+        <!--
+          optionally, supplier peer address can be specified below, otherwise the default (broker) is used
+        -->
+        <!--
+        <supplierInfo>
+          <supplierDescription>https://broker.crosslink-dev.indexdata.com/iso18626</supplierDescription>
+        </supplierInfo>
+        -->
+        <!--
+          optionally, requester peer address can be specified below, otherwise the default (broker) is used
+        -->
+        <!--
+        <requestingAgencyInfo>
+          <address>
+            <electronicAddress>
+              <electronicAddressType></electronicAddressType>
+              <electronicAddressData>https://broker.crosslink-dev.indexdata.com/iso8626</electronicAddressData>
+            </electronicAddress>
+          </address>
+        </requestingAgencyInfo>
+        -->
+    </request>
+</ISO18626Message>

--- a/service/src/main/groovy/org/olf/rs/referenceData/ActionEventResultData.groovy
+++ b/service/src/main/groovy/org/olf/rs/referenceData/ActionEventResultData.groovy
@@ -1060,6 +1060,7 @@ public class ActionEventResultData {
             requesterISO18626ExpectToSupply,
             requesterISO18626Unfilled,
             requesterISO18626UnfilledTransfer,
+            requesterISO18626Loaned,
             defaultNoStatusChangeOK
         ]
     ];

--- a/service/src/main/groovy/org/olf/rs/referenceData/RefdataValueData.groovy
+++ b/service/src/main/groovy/org/olf/rs/referenceData/RefdataValueData.groovy
@@ -146,6 +146,7 @@ public class RefdataValueData {
     // Request routing adapter
     public static final String REQUEST_ROUTING_ADAPTER_FOLIO_SHARED_INDEX = 'FOLIOSharedIndex';
     public static final String REQUEST_ROUTING_ADAPTER_STATIC             = 'Static';
+    public static final String REQUEST_ROUTING_ADAPTER_DISABLED           = 'Disabled';
 
     // Shared index adapter
     public static final String SHARED_INDEX_ADAPTER_FOLIO = 'FOLIO';
@@ -348,6 +349,8 @@ public class RefdataValueData {
 
             RefdataValue.lookupOrCreate(VOCABULARY_REQUEST_ROUTING_ADAPTER, REQUEST_ROUTING_ADAPTER_FOLIO_SHARED_INDEX);
             RefdataValue.lookupOrCreate(VOCABULARY_REQUEST_ROUTING_ADAPTER, REQUEST_ROUTING_ADAPTER_STATIC);
+            RefdataValue.lookupOrCreate(VOCABULARY_REQUEST_ROUTING_ADAPTER, REQUEST_ROUTING_ADAPTER_DISABLED);
+
 
             RefdataValue.lookupOrCreate(VOCABULARY_CURRENCY_CODES, 'Australian Dollars','AUD');
             RefdataValue.lookupOrCreate(VOCABULARY_CURRENCY_CODES, 'Canadian Dollars', 'CAD');

--- a/service/src/main/groovy/org/olf/rs/referenceData/SettingsData.groovy
+++ b/service/src/main/groovy/org/olf/rs/referenceData/SettingsData.groovy
@@ -98,6 +98,7 @@ public class SettingsData {
     public static final String SETTING_MAX_REQUESTS                    = 'max_requests';
     public static final String SETTING_REQUEST_ID_PREFIX               = 'request_id_prefix';
     public static final String SETTING_LOCAL_SYMBOLS                   = 'local_symbols';
+    public static final String SETTING_DEFAULT_PEER_SYMBOL             = 'default_peer_symbol';
 
     // Settings for the sharedIndex section
     public static final String SETTING_SHARED_INDEX_BASE_URL    = 'shared_index_base_url';
@@ -315,6 +316,7 @@ public class SettingsData {
             ensureAppSetting(SETTING_MAX_REQUESTS, SECTION_REQUESTS, SETTING_TYPE_STRING);
             ensureAppSetting(SETTING_DEFAULT_INSTITUTIONAL_PATRON_ID, SECTION_REQUESTS, SETTING_TYPE_STRING);
             ensureAppSetting(SETTING_LOCAL_SYMBOLS, SECTION_REQUESTS, SETTING_TYPE_STRING);
+            ensureAppSetting(SETTING_DEFAULT_PEER_SYMBOL, SECTION_REQUESTS, SETTING_TYPE_STRING);
 
             ensureAppSetting(SETTING_SHARED_INDEX_INTEGRATION, SECTION_SHARED_INDEX, SETTING_TYPE_REF_DATA, RefdataValueData.VOCABULARY_SHARED_INDEX_ADAPTER, null, referenceDataService.lookup(RefdataValueData.VOCABULARY_SHARED_INDEX_ADAPTER, RefdataValueData.SHARED_INDEX_ADAPTER_FOLIO).value);
             ensureAppSetting(SETTING_SHARED_INDEX_BASE_URL, SECTION_SHARED_INDEX, SETTING_TYPE_STRING, null, 'http://shared-index.reshare-dev.indexdata.com:9130');

--- a/tools/minio/docker-compose.yml
+++ b/tools/minio/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.1"
-
 volumes:
   minio_data:
     driver: local

--- a/tools/testing/docker-compose-apple-m2.yml
+++ b/tools/testing/docker-compose-apple-m2.yml
@@ -1,5 +1,3 @@
-version: "2.1"
-
 volumes:
   lsp_pgdata:
     driver: local

--- a/tools/testing/docker-compose.yml
+++ b/tools/testing/docker-compose.yml
@@ -22,6 +22,22 @@ services:
       - 5432:5432
       - 54321:5432
 
+  illmock:
+    image: ghcr.io/indexdata/crosslink-illmock:main
+    container_name: illmock
+    ports:
+       - "19083:8080"
+    environment:
+        HTTP_PORT: 8080
+        PEER_URL: "http://host.docker.internal:22553/rs/externalApi/iso18626"
+        HTTP_HEADERS: "X-Okapi-Tenant:NIAInstOne"
+        SUPPLYING_AGENCY_ID: NIA2
+        REQUESTING_AGENCY_ID: NIA1
+        MESSAGE_DELAY: 3000ms
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+
   # See https://github.com/simplesteph/kafka-stack-docker-compose
   zoo1:
     container_name: testing_zookeeper

--- a/tools/testing/docker-compose.yml
+++ b/tools/testing/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.1"
-
 volumes:
   lsp_pgdata:
     driver: local


### PR DESCRIPTION
This pull request encompasses the work described in issue https://index-data.atlassian.net/browse/RESH-20

The gist is to allow mod-rs to act as a "dumb" service while an external service handles things like building the rota and finding suppliers. The reliance on an external directory service is removed.

There are a few new settings to drive this new behavior. First and foremost, the reference data for the routing_adapter setting has been expanded with a new option, 'disabled'. Selecting disabled will tell mod-rs in a number of places not to use the rota to find suppliers and instead to rely on a configured gateway address.

Another new setting added is 'default_peer_symbol' which we must populate in order to properly generate outgoing requests when we aren't receiving peer information through the rota.

These changes have been implemented in a way that should be non-breaking for existing functionality. When the routing adapter setting is not disabled, mod-rs behaves as usual.

There are a few tweaks to mod-rs behavior that I want to highlight just for visibility:

- Previously, we had not been sending the SupplierUniqueId as part of the ISO message, due to the fact that we were populating this value through the rota. This has been changed so that the value is sent, but only if the originating request is a requester-side request rather than supply side. This was primarily needed because the mock ill server uses this field to select scenarios.

- Grails' default behavior for integration tests is to start mod-rs on a random port. Because we needed the mock server to be able to initiate requests with mod-rs, changes were made so that mod-rs will run on a static port. The current configured port is 22553, but this is changeable via the application.yml file.