### PR TITLE
Environment variables to selectively disable use of Kafka ILLDEV-98

### DIFF
--- a/service/grails-app/services/org/olf/rs/EventConsumerService.groovy
+++ b/service/grails-app/services/org/olf/rs/EventConsumerService.groovy
@@ -41,7 +41,7 @@ import groovy.transform.CompileStatic;
 @CompileStatic
 public class EventConsumerService implements EventPublisher, DataBinder {
 
-  private static final String TOPIC_PATRON_REQUESTS_SUFFIX = '_mod_rs_PatronRequestEvents'
+  public static final String TOPIC_PATRON_REQUESTS_SUFFIX = '_mod_rs_PatronRequestEvents'
   private static final String TOPIC_DIRECTORY_ENTRY_UPDATE_SUFFIX = '_mod_directory_DirectoryEntryUpdate'
 
   private static final String[] TOPIC_SUFFIXES = [TOPIC_PATRON_REQUESTS_SUFFIX, TOPIC_DIRECTORY_ENTRY_UPDATE_SUFFIX] as String[]
@@ -57,8 +57,8 @@ public class EventConsumerService implements EventPublisher, DataBinder {
 
   @javax.annotation.PostConstruct
   public void init() {
+    if (Boolean.parseBoolean(System.getenv('MOD_RS_DISABLE_KAFKA'))) return;
     log.debug("Configuring event consumer service")
-
     version = grailsApplication.metadata.applicationVersion ?: version
     final Properties props = new Properties()
     try {

--- a/service/grails-app/services/org/olf/rs/EventPublicationService.groovy
+++ b/service/grails-app/services/org/olf/rs/EventPublicationService.groovy
@@ -6,16 +6,19 @@ import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
 
+import grails.events.EventPublisher
 import grails.core.GrailsApplication
 
 
-public class EventPublicationService {
+public class EventPublicationService implements EventPublisher {
 
   private KafkaProducer producer = null;
+  private Boolean disableKafka = Boolean.parseBoolean(System.getenv('MOD_RS_DISABLE_KAFKA'));
   GrailsApplication grailsApplication
 
   @javax.annotation.PostConstruct
   public void init() {
+    if (disableKafka) return;
     log.debug("Configuring event publication service")
     Properties props = new Properties()
     grailsApplication.config.events.publisher.toProperties().each { final String key, final String value ->
@@ -35,15 +38,25 @@ public class EventPublicationService {
 
     log.debug("publishAsJSON(topic:${topic} key:${key}, event:${data?.event} tenant:${data?.tenant} oid:${data?.oid}  compoundMessage:...");
 
-    producer.send(
-        new ProducerRecord<String, String>(topic, key, compoundMessage), { RecordMetadata metadata, Exception e ->
-          // println "The offset of the record we just sent is: ${metadata?.offset()}"
-          if ( e != null ) {
-            println("Exception sending to kafka ${e}");
-            e.printStackTrace()
+    if ((disableKafka || Boolean.parseBoolean(System.getenv('MOD_RS_LOCAL_PR_EVENTS')))
+        && topic.endsWith(EventConsumerService.TOPIC_PATRON_REQUESTS_SUFFIX)) {
+      if ( data.event != null ) {
+        notify('PREventIndication', data)
+      }
+      else {
+        log.debug("No event specified in payoad: ${record.value()}")
+      }
+    } else {
+      producer.send(
+          new ProducerRecord<String, String>(topic, key, compoundMessage), { RecordMetadata metadata, Exception e ->
+            // println "The offset of the record we just sent is: ${metadata?.offset()}"
+            if ( e != null ) {
+              println("Exception sending to kafka ${e}");
+              e.printStackTrace()
+            }
           }
-        }
-    )
+      )
+    }
     log.debug("publishAsJSON - producer.send completed");
   }
 


### PR DESCRIPTION
MOD_RS_DISABLE_KAFKA=true will prevent use of Kafka

MOD_RS_LOCAL_PR_EVENTS=true will init Kafka and still use it for directory events but will use the Grails queue for PR ones