### PR TITLE
Instead of reverting original supplier symbol on local review, do it …

### DIFF
--- a/service/grails-app/services/org/olf/rs/statemodel/actions/ActionPatronRequestLocalSupplierCannotSupplyService.groovy
+++ b/service/grails-app/services/org/olf/rs/statemodel/actions/ActionPatronRequestLocalSupplierCannotSupplyService.groovy
@@ -3,7 +3,8 @@ package org.olf.rs.statemodel.actions;
 import org.olf.rs.PatronRequest
 import org.olf.rs.SettingsService
 import org.olf.rs.iso18626.ReasonForMessage
-import org.olf.rs.iso18626.TypeStatus;
+import org.olf.rs.iso18626.TypeStatus
+import org.olf.rs.referenceData.SettingsData;
 import org.olf.rs.statemodel.AbstractAction
 import org.olf.rs.statemodel.ActionEventResultQualifier
 import org.olf.rs.statemodel.ActionResultDetails;
@@ -29,7 +30,13 @@ public class ActionPatronRequestLocalSupplierCannotSupplyService extends Abstrac
         String requestRouterSetting = settingsService.getSettingValue('routing_adapter')
         if (requestRouterSetting == 'disabled') {
             reshareActionService.sendSupplyingAgencyMessage(request, ReasonForMessage.MESSAGE_REASON_STATUS_CHANGE, TypeStatus.UNFILLED.value(), [*: parameters], actionResultDetails)
-            actionResultDetails.qualifier = ActionEventResultQualifier.QUALIFIER_CONTINUE
+            actionResultDetails.qualifier = ActionEventResultQualifier.QUALIFIER_CONTINUE;
+            // Set supplying symbol back to the default
+            String defaultPeerSymbolString = settingsService.getSettingValue(SettingsData.SETTING_DEFAULT_PEER_SYMBOL);
+            if (defaultPeerSymbolString) {
+                log.debug("Setting supplying institution symbol to ${defaultPeerSymbolString}");
+                request.supplyingInstitutionSymbol = defaultPeerSymbolString;
+            }
         }
         return(actionResultDetails);
     }

--- a/service/grails-app/services/org/olf/rs/statemodel/events/EventStatusReqRequestSentToSupplierIndService.groovy
+++ b/service/grails-app/services/org/olf/rs/statemodel/events/EventStatusReqRequestSentToSupplierIndService.groovy
@@ -23,12 +23,6 @@ class EventStatusReqRequestSentToSupplierIndService extends AbstractEvent {
                 log.debug("Symbol ${request.supplyingInstitutionSymbol} is local");
                 eventResultDetails.qualifier = ActionEventResultQualifier.QUALIFIER_LOCAL_REVIEW;
                 eventResultDetails.auditMessage = 'Sent to local review';
-                // Set supplying symbol back to the default
-                String defaultPeerSymbolString = settingsService.getSettingValue(SettingsData.SETTING_DEFAULT_PEER_SYMBOL);
-                if (defaultPeerSymbolString) {
-                    log.debug("Setting supplying institution symbol to ${defaultPeerSymbolString}");
-                    request.supplyingInstitutionSymbol = defaultPeerSymbolString;
-                }
             }
         }
 


### PR DESCRIPTION
…in the 'local supplier cannot supply' action