### PR TITLE
Store sender symbol as string on notifications ILLDEV-194

### DIFF
--- a/service/grails-app/domain/org/olf/rs/PatronRequestNotification.groovy
+++ b/service/grails-app/domain/org/olf/rs/PatronRequestNotification.groovy
@@ -38,6 +38,7 @@ class PatronRequestNotification implements MultiTenant<PatronRequestNotification
   // The sender/receiver variables must be nullable, since we could have a system automated timeout notifcation etc
   Symbol messageSender
   Symbol messageReceiver
+  String senderSymbol
 
   // This will hold a String containing all the information to be displayed to the user
   String messageContent
@@ -55,6 +56,7 @@ class PatronRequestNotification implements MultiTenant<PatronRequestNotification
     isSender (nullable: true)
     messageSender (nullable: true)
     messageReceiver (nullable: true)
+    senderSymbol (nullable: true)
   }
 
   static mapping = {
@@ -70,6 +72,7 @@ class PatronRequestNotification implements MultiTenant<PatronRequestNotification
     actionData column: 'prn_action_data'
     messageSender column : 'prn_message_sender_fk'
     messageReceiver column : 'prn_message_receiver_fk'
+    senderSymbol column : 'prn_sender_symbol'
     messageContent column : 'prn_message_content'
     patronRequest column : 'prn_patron_request_fk'
   }

--- a/service/grails-app/migrations/update-mod-rs-2-19.groovy
+++ b/service/grails-app/migrations/update-mod-rs-2-19.groovy
@@ -64,5 +64,11 @@ databaseChangeLog = {
     changeSet(author: "knordstrom", id: '20250729-1543-001') {
         modifyDataType(tableName: "patron_request", columnName: "pr_patron_note", newDataType: "TEXT")
     }
+
+    changeSet(author: "jskomorowski", id: '20250828-1200-001') {
+        addColumn(tableName: "patron_request_notification") {
+            column(name: "prn_sender_symbol", type: "VARCHAR(255)")
+        }
+    }
      
 }

--- a/service/grails-app/services/org/olf/rs/ReshareApplicationEventHandlerService.groovy
+++ b/service/grails-app/services/org/olf/rs/ReshareApplicationEventHandlerService.groovy
@@ -386,11 +386,13 @@ public class ReshareApplicationEventHandlerService {
 
       inboundMessage.setMessageSender(DirectoryEntryService.resolveSymbol(eventData.header.supplyingAgencyId.agencyIdType, eventData.header.supplyingAgencyId.agencyIdValue))
       inboundMessage.setMessageReceiver(DirectoryEntryService.resolveSymbol(eventData.header.requestingAgencyId.agencyIdType, eventData.header.requestingAgencyId.agencyIdValue))
+      inboundMessage.setSenderSymbol("${eventData.header.supplyingAgencyId.agencyIdType}:${eventData.header.supplyingAgencyId.agencyIdValue}")
       inboundMessage.setAttachedAction(eventData.messageInfo.reasonForMessage)
       inboundMessage.setMessageContent(note)
     } else {
       inboundMessage.setMessageSender(DirectoryEntryService.resolveSymbol(eventData.header.requestingAgencyId.agencyIdType, eventData.header.requestingAgencyId.agencyIdValue))
       inboundMessage.setMessageReceiver(DirectoryEntryService.resolveSymbol(eventData.header.supplyingAgencyId.agencyIdType, eventData.header.supplyingAgencyId.agencyIdValue))
+      inboundMessage.setSenderSymbol("${eventData.header.requestingAgencyId.agencyIdType}:${eventData.header.requestingAgencyId.agencyIdValue}")
       inboundMessage.setAttachedAction(eventData.action)
       inboundMessage.setMessageContent(note)
     }


### PR DESCRIPTION
In systems without a sync'd directory table there'd otherwise be no way to determine which supplier sent the message as currently this is only through a directory entry fk